### PR TITLE
Generate message formats using serde_reflection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "ed25519"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +250,9 @@ dependencies = [
  "futures",
  "rand",
  "serde",
+ "serde-reflection",
+ "serde_yaml",
+ "structopt",
  "tokio",
 ]
 
@@ -456,6 +465,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -655,9 +670,9 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -756,18 +771,29 @@ checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 
 [[package]]
 name = "serde"
-version = "1.0.115"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.115"
+name = "serde-reflection"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+checksum = "43f97ce6635a8c9ababb7a7a7a309b7b00060e08b9131d37aa6fe1afce4f85b1"
+dependencies = [
+ "once_cell",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -783,6 +809,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -870,9 +908,9 @@ checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 
 [[package]]
 name = "syn"
-version = "1.0.39"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -907,6 +945,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1046,6 +1104,15 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -15,3 +15,12 @@ serde = { version = "1.0.115", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
 ed25519 = { version = "1.0.1"}
 ed25519-dalek = { version = "1.0.0-pre.3", features = ["batch"] }
+serde-reflection = "0.3.2"
+serde_yaml = "0.8.17"
+structopt = "0.3.21"
+
+[[bin]]
+name = "generate-format"
+path = "src/generate_format.rs"
+test = false
+

--- a/fastpay_core/src/base_types.rs
+++ b/fastpay_core/src/base_types.rs
@@ -3,7 +3,7 @@
 
 use ed25519::signature::Signature as _;
 use ed25519_dalek as dalek;
-use ed25519_dalek::{Digest, Signer, Verifier};
+use ed25519_dalek::{Signer, Verifier};
 
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
@@ -279,8 +279,11 @@ pub trait Digestible {
     fn digest(&self) -> [u8; 32];
 }
 
+#[cfg(test)]
 impl Digestible for [u8; 5] {
     fn digest(self: &[u8; 5]) -> [u8; 32] {
+        use ed25519_dalek::Digest;
+
         let mut h = dalek::Sha512::new();
         let mut hash = [0u8; 64];
         let mut digest = [0u8; 32];

--- a/fastpay_core/src/generate_format.rs
+++ b/fastpay_core/src/generate_format.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Facebook Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use fastpay_core::{error, messages, serialize};
+
+use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
+use std::{fs::File, io::Write};
+use structopt::{clap::arg_enum, StructOpt};
+
+fn get_registry() -> Result<Registry> {
+    let mut tracer = Tracer::new(TracerConfig::default());
+    let samples = Samples::new();
+    // 1. Record samples for types with custom deserializers.
+    // tracer.trace_value(&mut samples, ...)?;
+
+    // 2. Trace the main entry point(s) + every enum separately.
+    tracer.trace_type::<messages::Address>(&samples)?;
+    tracer.trace_type::<error::FastPayError>(&samples)?;
+    tracer.trace_type::<serialize::SerializedMessage>(&samples)?;
+    tracer.registry()
+}
+
+arg_enum! {
+#[derive(Debug, StructOpt, Clone, Copy)]
+enum Action {
+    Print,
+    Test,
+    Record,
+}
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "FastPay format generator",
+    about = "Trace serde (de)serialization to generate format descriptions for FastPay types"
+)]
+struct Options {
+    #[structopt(possible_values = &Action::variants(), default_value = "Print", case_insensitive = true)]
+    action: Action,
+}
+
+const FILE_PATH: &str = "fastpay_core/tests/staged/fastpay.yaml";
+
+fn main() {
+    let options = Options::from_args();
+    let registry = get_registry().unwrap();
+    match options.action {
+        Action::Print => {
+            let content = serde_yaml::to_string(&registry).unwrap();
+            println!("{}", content);
+        }
+        Action::Record => {
+            let content = serde_yaml::to_string(&registry).unwrap();
+            let mut f = File::create(FILE_PATH).unwrap();
+            writeln!(f, "{}", content).unwrap();
+        }
+        Action::Test => {
+            let f = File::open(FILE_PATH).unwrap();
+            let reference: serde_reflection::Registry = serde_yaml::from_reader(f).unwrap();
+            assert_eq!(registry, reference);
+        }
+    }
+}

--- a/fastpay_core/tests/format.rs
+++ b/fastpay_core/tests/format.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Facebook Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test]
+fn test_format() {
+    let status = std::process::Command::new("target/debug/generate-format")
+        .current_dir("..")
+        .arg("test")
+        .status()
+        .expect("failed to execute process");
+    assert!(status.success());
+}

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -1,0 +1,197 @@
+---
+AccountInfoRequest:
+  STRUCT:
+    - sender:
+        TYPENAME: EdPublicKeyBytes
+    - request_sequence_number:
+        OPTION:
+          TYPENAME: SequenceNumber
+    - request_received_transfers_excluding_first_nth:
+        OPTION: U64
+AccountInfoResponse:
+  STRUCT:
+    - sender:
+        TYPENAME: EdPublicKeyBytes
+    - balance:
+        TYPENAME: Balance
+    - next_sequence_number:
+        TYPENAME: SequenceNumber
+    - pending_confirmation:
+        OPTION:
+          TYPENAME: SignedTransferOrder
+    - requested_certificate:
+        OPTION:
+          TYPENAME: CertifiedTransferOrder
+    - requested_received_transfers:
+        SEQ:
+          TYPENAME: CertifiedTransferOrder
+Address:
+  ENUM:
+    0:
+      Primary:
+        NEWTYPE:
+          TYPENAME: EdPublicKeyBytes
+    1:
+      FastPay:
+        NEWTYPE:
+          TYPENAME: EdPublicKeyBytes
+Amount:
+  NEWTYPESTRUCT: U64
+Balance:
+  NEWTYPESTRUCT: I128
+CertifiedTransferOrder:
+  STRUCT:
+    - value:
+        TYPENAME: TransferOrder
+    - signatures:
+        SEQ:
+          TUPLE:
+            - TYPENAME: EdPublicKeyBytes
+            - TYPENAME: Signature
+EdPublicKeyBytes:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 32
+FastPayError:
+  ENUM:
+    0:
+      InvalidSignature:
+        STRUCT:
+          - error: STR
+    1:
+      UnknownSigner: UNIT
+    2:
+      CertificateRequiresQuorum: UNIT
+    3:
+      IncorrectTransferAmount: UNIT
+    4:
+      UnexpectedSequenceNumber: UNIT
+    5:
+      InsufficientFunding:
+        STRUCT:
+          - current_balance:
+              TYPENAME: Balance
+    6:
+      PreviousTransferMustBeConfirmedFirst:
+        STRUCT:
+          - pending_confirmation:
+              TYPENAME: TransferOrder
+    7:
+      ErrorWhileProcessingTransferOrder: UNIT
+    8:
+      ErrorWhileRequestingCertificate: UNIT
+    9:
+      MissingEalierConfirmations:
+        STRUCT:
+          - current_sequence_number:
+              TYPENAME: SequenceNumber
+    10:
+      UnexpectedTransactionIndex: UNIT
+    11:
+      CertificateNotfound: UNIT
+    12:
+      UnknownSenderAccount: UNIT
+    13:
+      CertificateAuthorityReuse: UNIT
+    14:
+      InvalidSequenceNumber: UNIT
+    15:
+      SequenceOverflow: UNIT
+    16:
+      SequenceUnderflow: UNIT
+    17:
+      AmountOverflow: UNIT
+    18:
+      AmountUnderflow: UNIT
+    19:
+      BalanceOverflow: UNIT
+    20:
+      BalanceUnderflow: UNIT
+    21:
+      WrongShard: UNIT
+    22:
+      InvalidCrossShardUpdate: UNIT
+    23:
+      InvalidDecoding: UNIT
+    24:
+      UnexpectedMessage: UNIT
+    25:
+      ClientIoError:
+        STRUCT:
+          - error: STR
+SequenceNumber:
+  NEWTYPESTRUCT: U64
+SerializedMessage:
+  ENUM:
+    0:
+      Order:
+        NEWTYPE:
+          TYPENAME: TransferOrder
+    1:
+      Vote:
+        NEWTYPE:
+          TYPENAME: SignedTransferOrder
+    2:
+      Cert:
+        NEWTYPE:
+          TYPENAME: CertifiedTransferOrder
+    3:
+      CrossShard:
+        NEWTYPE:
+          TYPENAME: CertifiedTransferOrder
+    4:
+      Error:
+        NEWTYPE:
+          TYPENAME: FastPayError
+    5:
+      InfoReq:
+        NEWTYPE:
+          TYPENAME: AccountInfoRequest
+    6:
+      InfoResp:
+        NEWTYPE:
+          TYPENAME: AccountInfoResponse
+Signature:
+  STRUCT:
+    - part1:
+        TUPLEARRAY:
+          CONTENT: U8
+          SIZE: 32
+    - part2:
+        TUPLEARRAY:
+          CONTENT: U8
+          SIZE: 32
+SignedTransferOrder:
+  STRUCT:
+    - value:
+        TYPENAME: TransferOrder
+    - authority:
+        TYPENAME: EdPublicKeyBytes
+    - signature:
+        TYPENAME: Signature
+Transfer:
+  STRUCT:
+    - sender:
+        TYPENAME: EdPublicKeyBytes
+    - recipient:
+        TYPENAME: Address
+    - amount:
+        TYPENAME: Amount
+    - sequence_number:
+        TYPENAME: SequenceNumber
+    - user_data:
+        TYPENAME: UserData
+TransferOrder:
+  STRUCT:
+    - transfer:
+        TYPENAME: Transfer
+    - signature:
+        TYPENAME: Signature
+UserData:
+  NEWTYPESTRUCT:
+    OPTION:
+      TUPLEARRAY:
+        CONTENT: U8
+        SIZE: 32
+


### PR DESCRIPTION
Add a command line tool to generate a format file meant for serde-generate. The result is committed to the repo and tested in a simple unit test.

Test:
```
cargo run --bin generate-format -- print
cargo run --bin generate-format -- test
cargo run --bin generate-format -- record
```

Usage:
```
cargo install serde-generate
serdegen --language java --target-source-dir test --with-runtimes serde bincode -- fastpay_core/tests/staged/fastpay.yaml
```