### PR TITLE
BCS signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,20 +175,22 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
 dependencies = [
+ "serde",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "merlin",
  "rand 0.7.3",
  "serde",
+ "serde_bytes",
  "sha2",
  "zeroize",
 ]
@@ -865,6 +867,15 @@ dependencies = [
  "once_cell",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "bcs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510fd83e3eaf7263b06182f3550b4c0af2af42cb36ab8024969ff5ea7fcb2833"
+dependencies = [
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +264,7 @@ name = "fastpay_core"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "bcs",
  "bincode",
  "ed25519",
  "ed25519-dalek",
@@ -261,6 +272,7 @@ dependencies = [
  "futures",
  "rand 0.7.3",
  "serde",
+ "serde-name",
  "serde-reflection",
  "serde_yaml",
  "structopt",
@@ -856,6 +868,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-name"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c47087018ec281d1cdab673d36aea22d816b54d498264029c05d5fa1910da6"
+dependencies = [
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -166,7 +166,7 @@ impl ClientServerBenchmark {
             };
             for i in 0..committee.quorum_threshold() {
                 let (pubx, secx) = keys.get(i).unwrap();
-                let sig = Signature::new(&certificate.value, secx);
+                let sig = Signature::new(&certificate.value.transfer, secx);
                 certificate.signatures.push((*pubx, sig));
             }
 

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -145,7 +145,7 @@ fn make_benchmark_certificates_from_orders_and_server_configs(
         };
         for i in 0..committee.quorum_threshold() {
             let (pubx, secx) = keys.get(i).unwrap();
-            let sig = Signature::new(&certificate.value, secx);
+            let sig = Signature::new(&certificate.value.transfer, secx);
             certificate.signatures.push((*pubx, sig));
         }
         let serialized_certificate = serialize_cert(&certificate);

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -38,7 +38,7 @@ impl AuthorityConfig {
 #[derive(Serialize, Deserialize)]
 pub struct AuthorityServerConfig {
     pub authority: AuthorityConfig,
-    pub key: SecretKey,
+    pub key: KeyPair,
 }
 
 impl AuthorityServerConfig {
@@ -97,7 +97,7 @@ pub struct UserAccount {
         deserialize_with = "address_from_base64"
     )]
     pub address: FastPayAddress,
-    pub key: SecretKey,
+    pub key: KeyPair,
     pub next_sequence_number: SequenceNumber,
     pub balance: Balance,
     pub sent_certificates: Vec<CertifiedTransferOrder>,

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.12.3"
+bcs = "0.1.3"
 bincode = "1.3.1"
 failure = "0.1.8"
 futures = "0.3.5"
@@ -16,6 +17,7 @@ tokio = { version = "0.2.22", features = ["full"] }
 ed25519 = { version = "1.0.1"}
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 serde-reflection = "0.3.2"
+serde-name = "0.1.2"
 serde_yaml = "0.8.17"
 structopt = "0.3.21"
 

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -14,7 +14,7 @@ rand = "0.7.3"
 serde = { version = "1.0.115", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
 ed25519 = { version = "1.0.1"}
-ed25519-dalek = { version = "1.0.0-pre.3", features = ["batch"] }
+ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 serde-reflection = "0.3.2"
 serde_yaml = "0.8.17"
 structopt = "0.3.21"

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -30,7 +30,7 @@ pub struct AuthorityState {
     /// Committee of this FastPay instance.
     pub committee: Committee,
     /// The signature key of the authority.
-    pub secret: SecretKey,
+    pub secret: KeyPair,
     /// Offchain states of FastPay accounts.
     pub accounts: BTreeMap<FastPayAddress, AccountOffchainState>,
     /// The latest transaction index of the blockchain that the authority has seen.
@@ -321,7 +321,7 @@ impl AccountOffchainState {
 }
 
 impl AuthorityState {
-    pub fn new(committee: Committee, name: AuthorityName, secret: SecretKey) -> Self {
+    pub fn new(committee: Committee, name: AuthorityName, secret: KeyPair) -> Self {
         AuthorityState {
             committee,
             name,
@@ -336,7 +336,7 @@ impl AuthorityState {
     pub fn new_shard(
         committee: Committee,
         name: AuthorityName,
-        secret: SecretKey,
+        secret: KeyPair,
         shard_id: u32,
         number_of_shards: u32,
     ) -> Self {

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -40,7 +40,7 @@ pub struct ClientState<AuthorityClient> {
     /// Our FastPay address.
     address: FastPayAddress,
     /// Our signature key.
-    secret: SecretKey,
+    secret: KeyPair,
     /// Our FastPay committee.
     committee: Committee,
     /// How to talk to this committee.
@@ -107,7 +107,7 @@ impl<A> ClientState<A> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         address: FastPayAddress,
-        secret: SecretKey,
+        secret: KeyPair,
         committee: Committee,
         authority_clients: HashMap<AuthorityName, A>,
         next_sequence_number: SequenceNumber,

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -148,7 +148,7 @@ impl Transfer {
 }
 
 impl TransferOrder {
-    pub fn new(transfer: Transfer, secret: &SecretKey) -> Self {
+    pub fn new(transfer: Transfer, secret: &KeyPair) -> Self {
         let signature = Signature::new(&transfer, secret);
         Self {
             transfer,
@@ -163,7 +163,7 @@ impl TransferOrder {
 
 impl SignedTransferOrder {
     /// Use signing key to create a signed object.
-    pub fn new(value: TransferOrder, authority: AuthorityName, secret: &SecretKey) -> Self {
+    pub fn new(value: TransferOrder, authority: AuthorityName, secret: &KeyPair) -> Self {
         let signature = Signature::new(&value.transfer, secret);
         Self {
             value,

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -468,7 +468,7 @@ fn init_state_with_account(address: FastPayAddress, balance: Balance) -> Authori
 #[cfg(test)]
 fn init_transfer_order(
     sender: FastPayAddress,
-    secret: &SecretKey,
+    secret: &KeyPair,
     recipient: Address,
     amount: Amount,
 ) -> TransferOrder {
@@ -485,7 +485,7 @@ fn init_transfer_order(
 #[cfg(test)]
 fn init_certified_transfer_order(
     sender: FastPayAddress,
-    secret: &SecretKey,
+    secret: &KeyPair,
     recipient: Address,
     amount: Amount,
     authority_state: &AuthorityState,

--- a/fastpay_core/src/unit_tests/base_types_tests.rs
+++ b/fastpay_core/src/unit_tests/base_types_tests.rs
@@ -1,17 +1,34 @@
 // Copyright (c) Facebook Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::blacklisted_name)]
+
 use super::*;
 
+#[derive(Serialize, Deserialize)]
+struct Foo(String);
+
+impl BcsSignable for Foo {}
+
+#[derive(Serialize, Deserialize)]
+struct Bar(String);
+
+impl BcsSignable for Bar {}
+
 #[test]
-fn test_fake_signatures() {
+fn test_signatures() {
     let (addr1, sec1) = get_key_pair();
     let (addr2, _sec2) = get_key_pair();
 
-    let s = Signature::new(b"hello", &sec1);
-    assert!(s.check(b"hello", addr1).is_ok());
-    assert!(s.check(b"hello", addr2).is_err());
-    assert!(s.check(b"hellx", addr1).is_err());
+    let foo = Foo("hello".into());
+    let foox = Foo("hellox".into());
+    let bar = Bar("hello".into());
+
+    let s = Signature::new(&foo, &sec1);
+    assert!(s.check(&foo, addr1).is_ok());
+    assert!(s.check(&foo, addr2).is_err());
+    assert!(s.check(&foox, addr1).is_err());
+    assert!(s.check(&bar, addr1).is_err());
 }
 
 #[test]

--- a/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
+++ b/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
@@ -131,7 +131,7 @@ fn test_handle_redeem_transaction_double_spend() {
 
 // helpers
 #[cfg(test)]
-fn init_contract() -> (FastPaySmartContractState, AuthorityName, SecretKey) {
+fn init_contract() -> (FastPaySmartContractState, AuthorityName, KeyPair) {
     let (authority_address, authority_key) = get_key_pair();
     let mut authorities = BTreeMap::new();
     authorities.insert(
@@ -157,7 +157,7 @@ fn init_funding_transaction() -> FundingTransaction {
 fn init_redeem_transaction(
     committee: Committee,
     name: AuthorityName,
-    secret: SecretKey,
+    secret: KeyPair,
 ) -> RedeemTransaction {
     let (sender_address, sender_key) = get_key_pair();
     let primary_transfer = Transfer {

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -137,7 +137,7 @@ fn test_cert() {
 
     for _ in 0..3 {
         let (authority_name, authority_key) = get_key_pair();
-        let sig = Signature::new(&cert.value, &authority_key);
+        let sig = Signature::new(&cert.value.transfer, &authority_key);
 
         cert.signatures.push((authority_name, sig));
     }
@@ -174,7 +174,7 @@ fn test_info_response() {
 
     for _ in 0..3 {
         let (authority_name, authority_key) = get_key_pair();
-        let sig = Signature::new(&cert.value, &authority_key);
+        let sig = Signature::new(&cert.value.transfer, &authority_key);
 
         cert.signatures.push((authority_name, sig));
     }
@@ -283,7 +283,9 @@ fn test_time_vote() {
     let now = Instant::now();
     for _ in 0..100 {
         if let SerializedMessage::Vote(vote) = deserialize_message(&mut buf2).unwrap() {
-            vote.signature.check(&vote.value, vote.authority).unwrap();
+            vote.signature
+                .check(&vote.value.transfer, vote.authority)
+                .unwrap();
         }
     }
     assert!(deserialize_message(&mut buf2).is_err());
@@ -312,7 +314,7 @@ fn test_time_cert() {
 
     for _ in 0..7 {
         let (authority_name, authority_key) = get_key_pair();
-        let sig = Signature::new(&cert.value, &authority_key);
+        let sig = Signature::new(&cert.value.transfer, &authority_key);
         cert.signatures.push((authority_name, sig));
     }
 
@@ -328,7 +330,7 @@ fn test_time_cert() {
     let mut buf2 = buf.as_slice();
     for _ in 0..count {
         if let SerializedMessage::Cert(cert) = deserialize_message(&mut buf2).unwrap() {
-            Signature::verify_batch(&cert.value, &cert.signatures).unwrap();
+            Signature::verify_batch(&cert.value.transfer, &cert.signatures).unwrap();
         }
     }
     assert!(deserialize_message(buf2).is_err());

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -2,7 +2,7 @@
 AccountInfoRequest:
   STRUCT:
     - sender:
-        TYPENAME: EdPublicKeyBytes
+        TYPENAME: PublicKeyBytes
     - request_sequence_number:
         OPTION:
           TYPENAME: SequenceNumber
@@ -11,7 +11,7 @@ AccountInfoRequest:
 AccountInfoResponse:
   STRUCT:
     - sender:
-        TYPENAME: EdPublicKeyBytes
+        TYPENAME: PublicKeyBytes
     - balance:
         TYPENAME: Balance
     - next_sequence_number:
@@ -30,11 +30,11 @@ Address:
     0:
       Primary:
         NEWTYPE:
-          TYPENAME: EdPublicKeyBytes
+          TYPENAME: PublicKeyBytes
     1:
       FastPay:
         NEWTYPE:
-          TYPENAME: EdPublicKeyBytes
+          TYPENAME: PublicKeyBytes
 Amount:
   NEWTYPESTRUCT: U64
 Balance:
@@ -46,13 +46,8 @@ CertifiedTransferOrder:
     - signatures:
         SEQ:
           TUPLE:
-            - TYPENAME: EdPublicKeyBytes
+            - TYPENAME: PublicKeyBytes
             - TYPENAME: Signature
-EdPublicKeyBytes:
-  NEWTYPESTRUCT:
-    TUPLEARRAY:
-      CONTENT: U8
-      SIZE: 32
 FastPayError:
   ENUM:
     0:
@@ -120,6 +115,11 @@ FastPayError:
       ClientIoError:
         STRUCT:
           - error: STR
+PublicKeyBytes:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 32
 SequenceNumber:
   NEWTYPESTRUCT: U64
 SerializedMessage:
@@ -162,13 +162,13 @@ SignedTransferOrder:
     - value:
         TYPENAME: TransferOrder
     - authority:
-        TYPENAME: EdPublicKeyBytes
+        TYPENAME: PublicKeyBytes
     - signature:
         TYPENAME: Signature
 Transfer:
   STRUCT:
     - sender:
-        TYPENAME: EdPublicKeyBytes
+        TYPENAME: PublicKeyBytes
     - recipient:
         TYPENAME: Address
     - amount:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -153,15 +153,10 @@ SerializedMessage:
         NEWTYPE:
           TYPENAME: AccountInfoResponse
 Signature:
-  STRUCT:
-    - part1:
-        TUPLEARRAY:
-          CONTENT: U8
-          SIZE: 32
-    - part2:
-        TUPLEARRAY:
-          CONTENT: U8
-          SIZE: 32
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 64
 SignedTransferOrder:
   STRUCT:
     - value:


### PR DESCRIPTION
* Use native representation and serialization of Dalek signatures
* Replace manual implementation of Digestible but a simple hashing implementation derived from BCS

Test plan: CI + `cargo test -- --ignored`