### PR TITLE
Candidate Extensions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, extensions ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, extensions ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ACCOUNT2="`tail -n -1 initial_accounts.txt | awk -F: '{ print $1 }'`"
 ./client --committee committee.json --accounts accounts.json benchmark
 
 # Inspect state of first account
-grep "$ACCOUNT1" accounts.json
+fgrep "$ACCOUNT1" accounts.json
 
 # Kill servers
 kill %1 %2 %3 %4 %5 %6 %7 %8 %9 %10 %11 %12 %13 %14 %15 %16

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -145,14 +145,12 @@ impl ClientServerBenchmark {
         let mut next_recipient = get_key_pair().0;
         for (pubx, secx) in account_keys.iter() {
             let transfer = Transfer {
-                sender: *pubx,
                 recipient: Address::FastPay(next_recipient),
                 amount: Amount::from(50),
                 sequence_number: SequenceNumber::from(0),
                 user_data: UserData::default(),
             };
-            next_recipient = *pubx;
-            let order = TransferOrder::new(transfer.clone(), secx);
+            let order = TransferOrder::new(*pubx, transfer.clone(), secx);
             let shard = AuthorityState::get_shard(self.num_shards, pubx);
 
             // Serialize order
@@ -175,6 +173,8 @@ impl ClientServerBenchmark {
 
             orders.push((shard, bufx2.into()));
             orders.push((shard, bufx.into()));
+
+            next_recipient = *pubx;
         }
 
         (states, orders)

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -121,13 +121,18 @@ impl ClientServerBenchmark {
             states.push(state);
         }
 
-        // Seed user accounts.
-        let mut account_keys = Vec::new();
-        for _ in 0..self.num_accounts {
-            let keypair = get_key_pair();
-            let i = AuthorityState::get_shard(self.num_shards, &keypair.0) as usize;
-            assert!(states[i].in_shard(&keypair.0));
+        // Seed user accounts and make one transaction per account (transfer order + confirmation).
+        info!("Preparing transactions.");
+        let mut orders: Vec<(u32, Bytes)> = Vec::new();
+        let mut next_recipient = AccountId(vec![((self.num_accounts - 1) as u64).into()]);
+        for i in 0..self.num_accounts {
+            // Create user account.
+            let id = AccountId(vec![(i as u64).into()]);
+            let (owner, keypair) = get_key_pair();
+            let shard = AuthorityState::get_shard(self.num_shards, &id) as usize;
+            assert!(states[shard].in_shard(&id));
             let client = AccountOffchainState {
+                owner,
                 balance: Balance::from(Amount::from(100)),
                 next_sequence_number: SequenceNumber::from(0),
                 pending_confirmation: None,
@@ -135,23 +140,17 @@ impl ClientServerBenchmark {
                 synchronization_log: Vec::new(),
                 received_log: Vec::new(),
             };
-            states[i].accounts.insert(keypair.0, client);
-            account_keys.push(keypair);
-        }
+            states[shard].accounts.insert(id.clone(), client);
 
-        info!("Preparing transactions.");
-        // Make one transaction per account (transfer order + confirmation).
-        let mut orders: Vec<(u32, Bytes)> = Vec::new();
-        let mut next_recipient = get_key_pair().0;
-        for (pubx, secx) in account_keys.iter() {
             let transfer = Transfer {
+                account_id: id.clone(),
                 recipient: Address::FastPay(next_recipient),
                 amount: Amount::from(50),
                 sequence_number: SequenceNumber::from(0),
                 user_data: UserData::default(),
             };
-            let order = TransferOrder::new(*pubx, transfer.clone(), secx);
-            let shard = AuthorityState::get_shard(self.num_shards, pubx);
+            let order = TransferOrder::new(transfer.clone(), &keypair);
+            let shard = AuthorityState::get_shard(self.num_shards, &id);
 
             // Serialize order
             let bufx = serialize_transfer_order(&order);
@@ -174,7 +173,7 @@ impl ClientServerBenchmark {
             orders.push((shard, bufx2.into()));
             orders.push((shard, bufx.into()));
 
-            next_recipient = *pubx;
+            next_recipient = id;
         }
 
         (states, orders)

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -144,10 +144,12 @@ impl ClientServerBenchmark {
 
             let transfer = Transfer {
                 account_id: id.clone(),
-                recipient: Address::FastPay(next_recipient),
-                amount: Amount::from(50),
+                operation: Operation::Payment {
+                    recipient: Address::FastPay(next_recipient),
+                    amount: Amount::from(50),
+                    user_data: UserData::default(),
+                },
                 sequence_number: SequenceNumber::from(0),
-                user_data: UserData::default(),
             };
             let order = TransferOrder::new(transfer.clone(), &key_pair);
             let shard = AuthorityState::get_shard(self.num_shards, &id);

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -123,10 +123,10 @@ impl ClientServerBenchmark {
         // Seed user accounts and make one transaction per account (transfer order + confirmation).
         info!("Preparing transactions.");
         let mut orders: Vec<(u32, Bytes)> = Vec::new();
-        let mut next_recipient = AccountId(vec![((self.num_accounts - 1) as u64).into()]);
+        let mut next_recipient = AccountId::new(vec![((self.num_accounts - 1) as u64).into()]);
         for i in 0..self.num_accounts {
             // Create user account.
-            let id = AccountId(vec![(i as u64).into()]);
+            let id = AccountId::new(vec![(i as u64).into()]);
             let key_pair = get_key_pair();
             let owner = key_pair.public();
             let shard = AuthorityState::get_shard(self.num_shards, &id) as usize;
@@ -136,6 +136,7 @@ impl ClientServerBenchmark {
                 balance: Balance::from(Amount::from(100)),
                 next_sequence_number: SequenceNumber::from(0),
                 pending_confirmation: None,
+                ongoing_confirmation: None,
                 confirmed_log: Vec::new(),
                 synchronization_log: Vec::new(),
                 received_log: Vec::new(),

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -249,7 +249,7 @@ fn mass_update_recipients(
     certificates: Vec<(AccountId, Bytes)>,
 ) {
     for (_sender, buf) in certificates {
-        if let Ok(SerializedMessage::Cert(certificate)) = deserialize_message(&buf[..]) {
+        if let Ok(SerializedMessage::Confirmation(certificate)) = deserialize_message(&buf[..]) {
             accounts_config.update_for_received_transfer(*certificate);
         }
     }
@@ -257,7 +257,7 @@ fn mass_update_recipients(
 
 fn deserialize_response(response: &[u8]) -> Option<AccountInfoResponse> {
     match deserialize_message(response) {
-        Ok(SerializedMessage::InfoResp(info)) => Some(*info),
+        Ok(SerializedMessage::InfoResponse(info)) => Some(*info),
         Ok(SerializedMessage::Error(error)) => {
             error!("Received error value: {}", error);
             None
@@ -531,7 +531,7 @@ fn main() {
         } => {
             for i in 0..num {
                 let account = UserAccount::new(
-                    AccountId(vec![SequenceNumber::from(i as u64)]),
+                    AccountId::new(vec![SequenceNumber::from(i as u64)]),
                     initial_funding,
                 );
                 println!(

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -99,10 +99,12 @@ fn make_benchmark_transfer_orders(
     for account in accounts_config.accounts_mut() {
         let transfer = Transfer {
             account_id: account.account_id.clone(),
-            recipient: Address::FastPay(next_recipient),
-            amount: Amount::from(1),
+            operation: Operation::Payment {
+                recipient: Address::FastPay(next_recipient),
+                amount: Amount::from(1),
+                user_data: UserData::default(),
+            },
             sequence_number: account.next_sequence_number,
-            user_data: UserData::default(),
         };
         debug!("Preparing transfer order: {:?}", transfer);
         account.next_sequence_number = account.next_sequence_number.increment().unwrap();

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -36,7 +36,7 @@ fn make_authority_clients(
             send_timeout,
             recv_timeout,
         );
-        authority_clients.insert(config.address, client);
+        authority_clients.insert(config.name, client);
     }
     authority_clients
 }
@@ -67,17 +67,17 @@ fn make_authority_mass_clients(
 fn make_client_state(
     accounts: &AccountsConfig,
     committee_config: &CommitteeConfig,
-    address: FastPayAddress,
+    account_id: AccountId,
     buffer_size: usize,
     send_timeout: std::time::Duration,
     recv_timeout: std::time::Duration,
 ) -> ClientState<network::Client> {
-    let account = accounts.get(&address).expect("Unknown account");
+    let account = accounts.get(&account_id).expect("Unknown account");
     let committee = Committee::new(committee_config.voting_rights());
     let authority_clients =
         make_authority_clients(committee_config, buffer_size, send_timeout, recv_timeout);
     ClientState::new(
-        address,
+        account_id,
         account.key.copy(),
         committee,
         authority_clients,
@@ -92,13 +92,13 @@ fn make_client_state(
 fn make_benchmark_transfer_orders(
     accounts_config: &mut AccountsConfig,
     max_orders: usize,
-) -> (Vec<TransferOrder>, Vec<(FastPayAddress, Bytes)>) {
+) -> (Vec<TransferOrder>, Vec<(AccountId, Bytes)>) {
     let mut orders = Vec::new();
     let mut serialized_orders = Vec::new();
-    // TODO: deterministic sequence of orders to recover from interrupted benchmarks.
-    let mut next_recipient = get_key_pair().0;
+    let mut next_recipient = accounts_config.last_account().unwrap().account_id.clone();
     for account in accounts_config.accounts_mut() {
         let transfer = Transfer {
+            account_id: account.account_id.clone(),
             recipient: Address::FastPay(next_recipient),
             amount: Amount::from(1),
             sequence_number: account.next_sequence_number,
@@ -106,14 +106,15 @@ fn make_benchmark_transfer_orders(
         };
         debug!("Preparing transfer order: {:?}", transfer);
         account.next_sequence_number = account.next_sequence_number.increment().unwrap();
-        let order = TransferOrder::new(account.address, transfer.clone(), &account.key);
+        let order = TransferOrder::new(transfer.clone(), &account.key);
         orders.push(order.clone());
         let serialized_order = serialize_transfer_order(&order);
-        serialized_orders.push((account.address, serialized_order.into()));
+        serialized_orders.push((account.account_id.clone(), serialized_order.into()));
         if serialized_orders.len() >= max_orders {
             break;
         }
-        next_recipient = account.address;
+
+        next_recipient = account.account_id.clone();
     }
     (orders, serialized_orders)
 }
@@ -122,11 +123,11 @@ fn make_benchmark_transfer_orders(
 fn make_benchmark_certificates_from_orders_and_server_configs(
     orders: Vec<TransferOrder>,
     server_config: Vec<&str>,
-) -> Vec<(FastPayAddress, Bytes)> {
+) -> Vec<(AccountId, Bytes)> {
     let mut keys = Vec::new();
     for file in server_config {
         let server_config = AuthorityServerConfig::read(file).expect("Fail to read server config");
-        keys.push((server_config.authority.address, server_config.key));
+        keys.push((server_config.authority.name, server_config.key));
     }
     let committee = Committee {
         voting_rights: keys.iter().map(|(k, _)| (*k, 1)).collect(),
@@ -148,7 +149,7 @@ fn make_benchmark_certificates_from_orders_and_server_configs(
             certificate.signatures.push((*pubx, sig));
         }
         let serialized_certificate = serialize_cert(&certificate);
-        serialized_certificates.push((order.sender, serialized_certificate.into()));
+        serialized_certificates.push((order.transfer.account_id, serialized_certificate.into()));
     }
     serialized_certificates
 }
@@ -157,32 +158,32 @@ fn make_benchmark_certificates_from_orders_and_server_configs(
 fn make_benchmark_certificates_from_votes(
     committee_config: &CommitteeConfig,
     votes: Vec<SignedTransferOrder>,
-) -> Vec<(FastPayAddress, Bytes)> {
+) -> Vec<(AccountId, Bytes)> {
     let committee = Committee::new(committee_config.voting_rights());
     let mut aggregators = HashMap::new();
     let mut certificates = Vec::new();
     let mut done_senders = HashSet::new();
     for vote in votes {
         // We aggregate votes indexed by sender.
-        let address = vote.value.sender;
-        if done_senders.contains(&address) {
+        let account_id = vote.value.transfer.account_id.clone();
+        if done_senders.contains(&account_id) {
             continue;
         }
         debug!(
-            "Processing vote on {}'s transfer by {}",
-            encode_address(&address),
-            encode_address(&vote.authority)
+            "Processing vote on {:?}'s transfer by {:?}",
+            account_id,
+            encode_pubkey(&vote.authority),
         );
         let value = vote.value;
         let aggregator = aggregators
-            .entry(address)
+            .entry(account_id.clone())
             .or_insert_with(|| SignatureAggregator::try_new(value, &committee).unwrap());
         match aggregator.append(vote.authority, vote.signature) {
             Ok(Some(certificate)) => {
                 debug!("Found certificate: {:?}", certificate);
                 let buf = serialize_cert(&certificate);
-                certificates.push((address, buf.into()));
-                done_senders.insert(address);
+                certificates.push((account_id.clone(), buf.into()));
+                done_senders.insert(account_id);
             }
             Ok(None) => {
                 debug!("Added one vote");
@@ -203,7 +204,7 @@ async fn mass_broadcast_orders(
     send_timeout: std::time::Duration,
     recv_timeout: std::time::Duration,
     max_in_flight: u64,
-    orders: Vec<(FastPayAddress, Bytes)>,
+    orders: Vec<(AccountId, Bytes)>,
 ) -> Vec<Bytes> {
     let time_start = Instant::now();
     info!("Broadcasting {} {} orders", orders.len(), phase);
@@ -218,8 +219,8 @@ async fn mass_broadcast_orders(
     for (num_shards, client) in authority_clients {
         // Re-index orders by shard for this particular authority client.
         let mut sharded_requests = HashMap::new();
-        for (address, buf) in &orders {
-            let shard = AuthorityState::get_shard(num_shards, address);
+        for (account_id, buf) in &orders {
+            let shard = AuthorityState::get_shard(num_shards, account_id);
             sharded_requests
                 .entry(shard)
                 .or_insert_with(Vec::new)
@@ -244,7 +245,7 @@ async fn mass_broadcast_orders(
 
 fn mass_update_recipients(
     accounts_config: &mut AccountsConfig,
-    certificates: Vec<(FastPayAddress, Bytes)>,
+    certificates: Vec<(AccountId, Bytes)>,
 ) {
     for (_sender, buf) in certificates {
         if let Ok(SerializedMessage::Cert(certificate)) = deserialize_message(&buf[..]) {
@@ -310,11 +311,11 @@ enum ClientCommands {
     /// Transfer funds
     #[structopt(name = "transfer")]
     Transfer {
-        /// Sending address (must be one of our accounts)
+        /// Sending account id (must be one of our accounts)
         #[structopt(long)]
         from: String,
 
-        /// Recipient address
+        /// Recipient account id
         #[structopt(long)]
         to: String,
 
@@ -325,8 +326,8 @@ enum ClientCommands {
     /// Obtain the spendable balance
     #[structopt(name = "query_balance")]
     QueryBalance {
-        /// Address of the account
-        address: String,
+        /// Account id
+        account_id: String,
     },
 
     /// Send one transfer per account in bulk mode
@@ -374,8 +375,8 @@ fn main() {
 
     match options.cmd {
         ClientCommands::Transfer { from, to, amount } => {
-            let sender = decode_address(&from).expect("Failed to decode sender's address");
-            let recipient = decode_address(&to).expect("Failed to decode recipient's address");
+            let sender = decode_id(&from).expect("Failed to decode sender's account id");
+            let recipient = decode_id(&to).expect("Failed to decode recipient's account id");
             let amount = Amount::from(amount);
 
             let mut rt = Runtime::new().unwrap();
@@ -391,7 +392,7 @@ fn main() {
                 info!("Starting transfer");
                 let time_start = Instant::now();
                 let cert = client_state
-                    .transfer_to_fastpay(amount, recipient, UserData::default())
+                    .transfer_to_fastpay(amount, recipient.clone(), UserData::default())
                     .await
                     .unwrap();
                 let time_total = time_start.elapsed().as_micros();
@@ -419,15 +420,15 @@ fn main() {
             });
         }
 
-        ClientCommands::QueryBalance { address } => {
-            let user_address = decode_address(&address).expect("Failed to decode address");
+        ClientCommands::QueryBalance { account_id } => {
+            let user_id = decode_id(&account_id).expect("Failed to decode account id");
 
             let mut rt = Runtime::new().unwrap();
             rt.block_on(async move {
                 let mut client_state = make_client_state(
                     &accounts_config,
                     &committee_config,
-                    user_address,
+                    user_id,
                     buffer_size,
                     send_timeout,
                     recv_timeout,
@@ -501,7 +502,7 @@ fn main() {
                         .iter()
                         .fold(0, |acc, buf| match deserialize_response(&buf[..]) {
                             Some(info) => {
-                                confirmed.insert(info.sender);
+                                confirmed.insert(info.account_id);
                                 acc + 1
                             }
                             None => acc,
@@ -527,10 +528,17 @@ fn main() {
             initial_funding,
             num,
         } => {
-            let num_accounts: u32 = num;
-            for _ in 0..num_accounts {
-                let account = UserAccount::new(initial_funding);
-                println!("{}:{}", encode_address(&account.address), initial_funding);
+            for i in 0..num {
+                let account = UserAccount::new(
+                    AccountId(vec![SequenceNumber::from(i as u64)]),
+                    initial_funding,
+                );
+                println!(
+                    "{}:{}:{}",
+                    encode_id(&account.account_id),
+                    encode_pubkey(&account.key.public()),
+                    initial_funding,
+                );
                 accounts_config.insert(account);
             }
             accounts_config

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -102,7 +102,7 @@ pub struct UserAccount {
 
 impl UserAccount {
     pub fn new(account_id: AccountId, balance: Balance) -> Self {
-        let (_, key) = get_key_pair();
+        let key = get_key_pair();
         Self {
             account_id,
             key,

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -19,10 +19,10 @@ use std::{
 pub struct AuthorityConfig {
     pub network_protocol: NetworkProtocol,
     #[serde(
-        serialize_with = "address_as_base64",
-        deserialize_with = "address_from_base64"
+        serialize_with = "pubkey_as_base64",
+        deserialize_with = "pubkey_from_base64"
     )]
-    pub address: FastPayAddress,
+    pub name: AuthorityName,
     pub host: String,
     pub base_port: u32,
     pub num_shards: u32,
@@ -84,7 +84,7 @@ impl CommitteeConfig {
     pub fn voting_rights(&self) -> BTreeMap<AuthorityName, usize> {
         let mut map = BTreeMap::new();
         for authority in &self.authorities {
-            map.insert(authority.address, 1);
+            map.insert(authority.name, 1);
         }
         map
     }
@@ -92,11 +92,7 @@ impl CommitteeConfig {
 
 #[derive(Serialize, Deserialize)]
 pub struct UserAccount {
-    #[serde(
-        serialize_with = "address_as_base64",
-        deserialize_with = "address_from_base64"
-    )]
-    pub address: FastPayAddress,
+    pub account_id: AccountId,
     pub key: KeyPair,
     pub next_sequence_number: SequenceNumber,
     pub balance: Balance,
@@ -105,10 +101,10 @@ pub struct UserAccount {
 }
 
 impl UserAccount {
-    pub fn new(balance: Balance) -> Self {
-        let (address, key) = get_key_pair();
+    pub fn new(account_id: AccountId, balance: Balance) -> Self {
+        let (_, key) = get_key_pair();
         Self {
-            address,
+            account_id,
             key,
             next_sequence_number: SequenceNumber::new(),
             balance,
@@ -119,20 +115,24 @@ impl UserAccount {
 }
 
 pub struct AccountsConfig {
-    accounts: BTreeMap<FastPayAddress, UserAccount>,
+    accounts: BTreeMap<AccountId, UserAccount>,
 }
 
 impl AccountsConfig {
-    pub fn get(&self, address: &FastPayAddress) -> Option<&UserAccount> {
-        self.accounts.get(address)
+    pub fn get(&self, account_id: &AccountId) -> Option<&UserAccount> {
+        self.accounts.get(account_id)
     }
 
     pub fn insert(&mut self, account: UserAccount) {
-        self.accounts.insert(account.address, account);
+        self.accounts.insert(account.account_id.clone(), account);
     }
 
     pub fn num_accounts(&self) -> usize {
         self.accounts.len()
+    }
+
+    pub fn last_account(&mut self) -> Option<&UserAccount> {
+        self.accounts.values().last()
     }
 
     pub fn accounts_mut(&mut self) -> impl Iterator<Item = &mut UserAccount> {
@@ -142,8 +142,9 @@ impl AccountsConfig {
     pub fn update_from_state<A>(&mut self, state: &ClientState<A>) {
         let account = self
             .accounts
-            .get_mut(&state.address())
+            .get_mut(state.account_id())
             .expect("Updated account should already exist");
+        // account.key = state.secret().copy(); // TODO: support key rotations
         account.next_sequence_number = state.next_sequence_number();
         account.balance = state.balance();
         account.sent_certificates = state.sent_certificates().clone();
@@ -176,7 +177,7 @@ impl AccountsConfig {
         Ok(Self {
             accounts: stream
                 .filter_map(Result::ok)
-                .map(|account: UserAccount| (account.address, account))
+                .map(|account: UserAccount| (account.account_id.clone(), account))
                 .collect(),
         })
     }
@@ -193,7 +194,7 @@ impl AccountsConfig {
 }
 
 pub struct InitialStateConfig {
-    pub accounts: Vec<(FastPayAddress, Balance)>,
+    pub accounts: Vec<(AccountId, AccountOwner, Balance)>,
 }
 
 impl InitialStateConfig {
@@ -204,12 +205,13 @@ impl InitialStateConfig {
         for line in reader.lines() {
             let line = line?;
             let elements = line.split(':').collect::<Vec<_>>();
-            if elements.len() != 2 {
-                failure::bail!("expecting two columns separated with ':'")
+            if elements.len() != 3 {
+                failure::bail!("expecting three columns separated with ':'")
             }
-            let address = decode_address(elements[0])?;
-            let balance = elements[1].parse()?;
-            accounts.push((address, balance));
+            let id = decode_id(elements[0])?;
+            let pubkey = decode_pubkey(elements[1])?;
+            let balance = elements[2].parse()?;
+            accounts.push((id, pubkey, balance));
         }
         Ok(Self { accounts })
     }
@@ -217,8 +219,14 @@ impl InitialStateConfig {
     pub fn write(&self, path: &str) -> Result<(), std::io::Error> {
         let file = OpenOptions::new().create(true).write(true).open(path)?;
         let mut writer = BufWriter::new(file);
-        for (address, balance) in &self.accounts {
-            writeln!(writer, "{}:{}", encode_address(address), balance)?;
+        for (id, pubkey, balance) in &self.accounts {
+            writeln!(
+                writer,
+                "{}:{}:{}",
+                encode_id(id),
+                encode_pubkey(pubkey),
+                balance
+            )?;
         }
         Ok(())
     }

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -156,7 +156,7 @@ impl AccountsConfig {
             if let Some(config) = self.accounts.get_mut(recipient) {
                 if let Err(position) = config
                     .received_certificates
-                    .binary_search_by_key(&certificate.key(), CertifiedTransferOrder::key)
+                    .binary_search_by_key(&certificate.value.key(), |order| order.value.key())
                 {
                     config.balance = config.balance.try_add(transfer.amount.into()).unwrap();
                     config.received_certificates.insert(position, certificate)

--- a/fastpay/src/network.rs
+++ b/fastpay/src/network.rs
@@ -293,7 +293,7 @@ impl AuthorityClient for Client {
         order: TransferOrder,
     ) -> AsyncResult<AccountInfoResponse, FastPayError> {
         Box::pin(async move {
-            let shard = AuthorityState::get_shard(self.num_shards, &order.sender);
+            let shard = AuthorityState::get_shard(self.num_shards, &order.transfer.account_id);
             self.send_recv_bytes(shard, serialize_transfer_order(&order))
                 .await
         })
@@ -307,7 +307,7 @@ impl AuthorityClient for Client {
         Box::pin(async move {
             let shard = AuthorityState::get_shard(
                 self.num_shards,
-                &order.transfer_certificate.value.sender,
+                &order.transfer_certificate.value.transfer.account_id,
             );
             self.send_recv_bytes(shard, serialize_cert(&order.transfer_certificate))
                 .await
@@ -320,7 +320,7 @@ impl AuthorityClient for Client {
         request: AccountInfoRequest,
     ) -> AsyncResult<AccountInfoResponse, FastPayError> {
         Box::pin(async move {
-            let shard = AuthorityState::get_shard(self.num_shards, &request.sender);
+            let shard = AuthorityState::get_shard(self.num_shards, &request.account_id);
             self.send_recv_bytes(shard, serialize_info_request(&request))
                 .await
         })

--- a/fastpay/src/network.rs
+++ b/fastpay/src/network.rs
@@ -293,7 +293,7 @@ impl AuthorityClient for Client {
         order: TransferOrder,
     ) -> AsyncResult<AccountInfoResponse, FastPayError> {
         Box::pin(async move {
-            let shard = AuthorityState::get_shard(self.num_shards, &order.transfer.sender);
+            let shard = AuthorityState::get_shard(self.num_shards, &order.sender);
             self.send_recv_bytes(shard, serialize_transfer_order(&order))
                 .await
         })
@@ -307,7 +307,7 @@ impl AuthorityClient for Client {
         Box::pin(async move {
             let shard = AuthorityState::get_shard(
                 self.num_shards,
-                &order.transfer_certificate.value.transfer.sender,
+                &order.transfer_certificate.value.sender,
             );
             self.send_recv_bytes(shard, serialize_cert(&order.transfer_certificate))
                 .await

--- a/fastpay/src/network.rs
+++ b/fastpay/src/network.rs
@@ -140,29 +140,17 @@ impl MessageHandler for RunningServerState {
                             .state
                             .handle_transfer_order(*message)
                             .map(|info| Some(serialize_info_response(&info))),
-                        SerializedMessage::Cert(message) => {
+                        SerializedMessage::Confirmation(message) => {
                             let confirmation_order = ConfirmationOrder {
-                                transfer_certificate: message.as_ref().clone(),
+                                transfer_certificate: *message,
                             };
                             match self
                                 .server
                                 .state
                                 .handle_confirmation_order(confirmation_order)
                             {
-                                Ok((info, send_shard)) => {
-                                    // Send a message to other shard
-                                    if let Some(cross_shard_update) = send_shard {
-                                        let shard = cross_shard_update.shard_id;
-                                        let tmp_out = serialize_cross_shard(&message);
-                                        debug!(
-                                            "Scheduling cross shard query: {} -> {}",
-                                            self.server.state.shard_id, shard
-                                        );
-                                        self.cross_shard_sender
-                                            .send((tmp_out, shard))
-                                            .await
-                                            .expect("internal channel should not fail");
-                                    };
+                                Ok((info, continuation)) => {
+                                    self.handle_continuation(continuation).await;
 
                                     // Response
                                     Ok(Some(serialize_info_response(&info)))
@@ -170,23 +158,42 @@ impl MessageHandler for RunningServerState {
                                 Err(error) => Err(error),
                             }
                         }
-                        SerializedMessage::InfoReq(message) => self
+                        SerializedMessage::InfoRequest(message) => self
                             .server
                             .state
                             .handle_account_info_request(*message)
                             .map(|info| Some(serialize_info_response(&info))),
-                        SerializedMessage::CrossShard(message) => {
-                            match self
-                                .server
-                                .state
-                                .handle_cross_shard_recipient_commit(*message)
-                            {
-                                Ok(_) => Ok(None), // Nothing to reply
+                        SerializedMessage::CrossShardRequest(request) => {
+                            use CrossShardRequest::*;
+                            let result = match *request {
+                                UpdateRecipientAccount { certificate } => {
+                                    self.server.state.update_recipient_account(certificate)
+                                }
+                                VerifyAccountDeletion {
+                                    parent_id,
+                                    sequence_number,
+                                    certificate,
+                                } => self.server.state.verify_account_deletion(
+                                    parent_id,
+                                    sequence_number,
+                                    certificate,
+                                ),
+                                UpdateSenderAccount {
+                                    certificate,
+                                    outcome,
+                                } => self
+                                    .server
+                                    .state
+                                    .update_sender_account(certificate, outcome),
+                            };
+                            match result {
+                                Ok(cont) => self.handle_continuation(cont).await,
                                 Err(error) => {
-                                    error!("Failed to handle cross-shard query: {}", error);
-                                    Ok(None) // Nothing to reply
+                                    error!("Failed to handle cross-shard request: {}", error);
                                 }
                             }
+                            // No user to respond to.
+                            Ok(None)
                         }
                         _ => Err(FastPayError::UnexpectedMessage),
                     }
@@ -210,6 +217,31 @@ impl MessageHandler for RunningServerState {
                     warn!("User query failed: {}", error);
                     self.server.user_errors += 1;
                     Some(serialize_error(&error))
+                }
+            }
+        })
+    }
+}
+
+impl RunningServerState {
+    fn handle_continuation(
+        &mut self,
+        continuation: CrossShardContinuation,
+    ) -> futures::future::BoxFuture<()> {
+        Box::pin(async move {
+            use CrossShardContinuation::*;
+            match continuation {
+                Done => (),
+                Request { shard_id, request } => {
+                    let buffer = serialize_cross_shard_request(&request);
+                    debug!(
+                        "Scheduling cross shard query: {} -> {}",
+                        self.server.state.shard_id, shard_id
+                    );
+                    self.cross_shard_sender
+                        .send((buffer, shard_id))
+                        .await
+                        .expect("internal channel should not fail");
                 }
             }
         })
@@ -276,7 +308,7 @@ impl Client {
             Ok(response) => {
                 // Parse reply
                 match deserialize_message(&response[..]) {
-                    Ok(SerializedMessage::InfoResp(resp)) => Ok(*resp),
+                    Ok(SerializedMessage::InfoResponse(resp)) => Ok(*resp),
                     Ok(SerializedMessage::Error(error)) => Err(*error),
                     Err(_) => Err(FastPayError::InvalidDecoding),
                     _ => Err(FastPayError::UnexpectedMessage),

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -44,6 +44,7 @@ fn make_shard_server(
             balance: *balance,
             next_sequence_number: SequenceNumber::from(0),
             pending_confirmation: None,
+            ongoing_confirmation: None,
             confirmed_log: Vec::new(),
             synchronization_log: Vec::new(),
             received_log: Vec::new(),

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -33,18 +33,19 @@ fn make_shard_server(
 
     let mut state = AuthorityState::new_shard(
         committee,
-        server_config.authority.address,
+        server_config.authority.name,
         server_config.key.copy(),
         shard,
         num_shards,
     );
 
     // Load initial states
-    for (address, balance) in &initial_accounts_config.accounts {
-        if AuthorityState::get_shard(num_shards, address) != shard {
+    for (id, owner, balance) in &initial_accounts_config.accounts {
+        if AuthorityState::get_shard(num_shards, id) != shard {
             continue;
         }
         let client = AccountOffchainState {
+            owner: *owner,
             balance: *balance,
             next_sequence_number: SequenceNumber::from(0),
             pending_confirmation: None,
@@ -52,7 +53,7 @@ fn make_shard_server(
             synchronization_log: Vec::new(),
             received_log: Vec::new(),
         };
-        state.accounts.insert(*address, client);
+        state.accounts.insert(id.clone(), client);
     }
 
     network::Server::new(
@@ -221,10 +222,10 @@ fn main() {
             port,
             shards,
         } => {
-            let (address, key) = get_key_pair();
+            let (name, key) = get_key_pair();
             let authority = AuthorityConfig {
                 network_protocol: protocol,
-                address,
+                name,
                 host,
                 base_port: port,
                 num_shards: shards,

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -31,13 +31,8 @@ fn make_shard_server(
     let committee = Committee::new(committee_config.voting_rights());
     let num_shards = server_config.authority.num_shards;
 
-    let mut state = AuthorityState::new_shard(
-        committee,
-        server_config.authority.name,
-        server_config.key.copy(),
-        shard,
-        num_shards,
-    );
+    let mut state =
+        AuthorityState::new_shard(committee, server_config.key.copy(), shard, num_shards);
 
     // Load initial states
     for (id, owner, balance) in &initial_accounts_config.accounts {
@@ -222,7 +217,8 @@ fn main() {
             port,
             shards,
         } => {
-            let (name, key) = get_key_pair();
+            let key = get_key_pair();
+            let name = key.public();
             let authority = AuthorityConfig {
                 network_protocol: protocol,
                 name,

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 edition = "2018"
 
 [dependencies]
-base64 = "0.12.3"
 bcs = "0.1.3"
 bincode = "1.3.1"
 failure = "0.1.8"
 futures = "0.3.5"
+hex = "0.4.3"
 rand = "0.7.3"
 serde = { version = "1.0.115", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.115", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
 ed25519 = { version = "1.0.1"}
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
+serde_json = "1.0.57"
 serde-reflection = "0.3.2"
 serde-name = "0.1.2"
 serde_yaml = "0.8.17"

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -486,6 +486,7 @@ impl AccountOffchainState {
             balance: self.balance,
             next_sequence_number: self.next_sequence_number,
             pending_confirmation: self.pending_confirmation.clone(),
+            ongoing_confirmation: self.ongoing_confirmation.clone(),
             requested_certificate: None,
             requested_received_transfers: Vec::new(),
         }

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -32,8 +32,8 @@ pub struct AuthorityState {
     pub name: AuthorityName,
     /// Committee of this FastPay instance.
     pub committee: Committee,
-    /// The signature key of the authority.
-    pub secret: KeyPair,
+    /// The signature key pair of the authority.
+    pub key_pair: KeyPair,
     /// Offchain states of FastPay accounts.
     pub accounts: BTreeMap<AccountId, AccountOffchainState>,
     /// The latest transaction index of the blockchain that the authority has seen.
@@ -126,7 +126,7 @@ impl Authority for AuthorityState {
                         current_balance: account.balance
                     }
                 );
-                let signed_order = SignedTransferOrder::new(order, self.name, &self.secret);
+                let signed_order = SignedTransferOrder::new(order, &self.key_pair);
                 account.pending_confirmation = Some(signed_order);
                 Ok(account.make_account_info(account_id))
             }
@@ -327,11 +327,11 @@ impl AccountOffchainState {
 }
 
 impl AuthorityState {
-    pub fn new(committee: Committee, name: AuthorityName, secret: KeyPair) -> Self {
+    pub fn new(committee: Committee, name: AuthorityName, key_pair: KeyPair) -> Self {
         AuthorityState {
             committee,
             name,
-            secret,
+            key_pair,
             accounts: BTreeMap::new(),
             last_transaction_index: VersionNumber::new(),
             shard_id: 0,
@@ -341,15 +341,14 @@ impl AuthorityState {
 
     pub fn new_shard(
         committee: Committee,
-        name: AuthorityName,
-        secret: KeyPair,
+        key_pair: KeyPair,
         shard_id: u32,
         number_of_shards: u32,
     ) -> Self {
         AuthorityState {
             committee,
-            name,
-            secret,
+            name: key_pair.public(),
+            key_pair,
             accounts: BTreeMap::new(),
             last_transaction_index: VersionNumber::new(),
             shard_id,

--- a/fastpay_core/src/base_types.rs
+++ b/fastpay_core/src/base_types.rs
@@ -46,10 +46,10 @@ pub type PrimaryAddress = PublicKeyBytes;
 pub type AuthorityName = PublicKeyBytes;
 pub type AccountOwner = PublicKeyBytes;
 
-pub fn get_key_pair() -> (PublicKeyBytes, KeyPair) {
+pub fn get_key_pair() -> KeyPair {
     let mut csprng = OsRng;
     let keypair = dalek::Keypair::generate(&mut csprng);
-    (PublicKeyBytes(keypair.public.to_bytes()), KeyPair(keypair))
+    KeyPair(keypair)
 }
 
 pub fn pubkey_as_base64<S>(key: &PublicKeyBytes, serializer: S) -> Result<S::Ok, S::Error>

--- a/fastpay_core/src/base_types.rs
+++ b/fastpay_core/src/base_types.rs
@@ -43,7 +43,7 @@ pub struct KeyPair(dalek::Keypair);
 pub struct PublicKeyBytes(pub [u8; dalek::PUBLIC_KEY_LENGTH]);
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Serialize, Deserialize)]
-pub struct AccountId(pub Vec<SequenceNumber>);
+pub struct AccountId(Vec<SequenceNumber>);
 
 pub type PrimaryAddress = PublicKeyBytes;
 pub type AuthorityName = PublicKeyBytes;
@@ -240,6 +240,24 @@ impl std::fmt::Debug for AccountId {
 }
 
 impl AccountId {
+    pub fn new(numbers: Vec<SequenceNumber>) -> Self {
+        assert!(!numbers.is_empty());
+        Self(numbers)
+    }
+
+    pub fn parent(&self) -> Option<AccountId> {
+        if self.0.len() <= 1 {
+            return None;
+        }
+        let mut parent = self.clone();
+        parent.0.pop()?;
+        Some(parent)
+    }
+
+    pub fn sequence_number(&self) -> Option<SequenceNumber> {
+        self.0.last().cloned()
+    }
+
     pub fn make_child(&self, num: SequenceNumber) -> Self {
         let mut id = self.clone();
         id.0.push(num);

--- a/fastpay_core/src/base_types.rs
+++ b/fastpay_core/src/base_types.rs
@@ -239,6 +239,14 @@ impl std::fmt::Debug for AccountId {
     }
 }
 
+impl AccountId {
+    pub fn make_child(&self, num: SequenceNumber) -> Self {
+        let mut id = self.clone();
+        id.0.push(num);
+        id
+    }
+}
+
 impl Amount {
     pub fn zero() -> Self {
         Amount(0)

--- a/fastpay_core/src/base_types.rs
+++ b/fastpay_core/src/base_types.rs
@@ -6,7 +6,10 @@ use ed25519_dalek::{Signer, Verifier};
 
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    str::FromStr,
+};
 
 use crate::error::FastPayError;
 
@@ -36,11 +39,11 @@ pub struct UserData(pub Option<[u8; 32]>);
 // TODO: Make sure secrets are not copyable and movable to control where they are in memory
 pub struct KeyPair(dalek::Keypair);
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash)]
 pub struct PublicKeyBytes(pub [u8; dalek::PUBLIC_KEY_LENGTH]);
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Hash, Serialize, Deserialize)]
-pub struct AccountId(pub Vec<SequenceNumber>); // TODO: abstract APIs
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Serialize, Deserialize)]
+pub struct AccountId(pub Vec<SequenceNumber>);
 
 pub type PrimaryAddress = PublicKeyBytes;
 pub type AuthorityName = PublicKeyBytes;
@@ -50,41 +53,6 @@ pub fn get_key_pair() -> KeyPair {
     let mut csprng = OsRng;
     let keypair = dalek::Keypair::generate(&mut csprng);
     KeyPair(keypair)
-}
-
-pub fn pubkey_as_base64<S>(key: &PublicKeyBytes, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::ser::Serializer,
-{
-    serializer.serialize_str(&encode_pubkey(key))
-}
-
-pub fn pubkey_from_base64<'de, D>(deserializer: D) -> Result<PublicKeyBytes, D::Error>
-where
-    D: serde::de::Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    let value = decode_pubkey(&s).map_err(|err| serde::de::Error::custom(err.to_string()))?;
-    Ok(value)
-}
-
-pub fn encode_pubkey(key: &PublicKeyBytes) -> String {
-    base64::encode(&key.0[..])
-}
-
-pub fn decode_pubkey(s: &str) -> Result<PublicKeyBytes, failure::Error> {
-    let value = base64::decode(s)?;
-    let mut pubkey = [0u8; dalek::PUBLIC_KEY_LENGTH];
-    pubkey.copy_from_slice(&value[..dalek::PUBLIC_KEY_LENGTH]);
-    Ok(PublicKeyBytes(pubkey))
-}
-
-pub fn encode_id(id: &AccountId) -> String {
-    serde_json::to_string(&id.0).unwrap()
-}
-
-pub fn decode_id(s: &str) -> Result<AccountId, failure::Error> {
-    Ok(AccountId(serde_json::from_str(s)?))
 }
 
 #[cfg(test)]
@@ -98,7 +66,7 @@ pub fn dbg_addr(name: u8) -> PublicKeyBytes {
     PublicKeyBytes(addr)
 }
 
-#[derive(Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Copy, Clone)]
 pub struct Signature(dalek::Signature);
 
 impl KeyPair {
@@ -115,41 +83,159 @@ impl KeyPair {
     }
 }
 
+impl Serialize for PublicKeyBytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.to_string())
+        } else {
+            serializer.serialize_newtype_struct("PublicKeyBytes", &self.0)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PublicKeyBytes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            let value =
+                Self::from_str(&s).map_err(|err| serde::de::Error::custom(err.to_string()))?;
+            Ok(value)
+        } else {
+            #[derive(Deserialize)]
+            #[serde(rename = "PublicKeyBytes")]
+            struct Foo([u8; dalek::PUBLIC_KEY_LENGTH]);
+
+            let value = Foo::deserialize(deserializer)?;
+            Ok(Self(value.0))
+        }
+    }
+}
+
 impl Serialize for KeyPair {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::ser::Serializer,
     {
-        serializer.serialize_str(&base64::encode(&self.0.to_bytes()))
+        // This is only used for JSON configuration.
+        assert!(serializer.is_human_readable());
+        serializer.serialize_str(&hex::encode(&self.0.to_bytes()))
     }
 }
 
 impl<'de> Deserialize<'de> for KeyPair {
-    fn deserialize<D>(deserializer: D) -> Result<KeyPair, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::de::Deserializer<'de>,
     {
+        // This is only used for JSON configuration.
+        assert!(deserializer.is_human_readable());
         let s = String::deserialize(deserializer)?;
-        let value = base64::decode(&s).map_err(|err| serde::de::Error::custom(err.to_string()))?;
+        let value = hex::decode(&s).map_err(|err| serde::de::Error::custom(err.to_string()))?;
         let key = dalek::Keypair::from_bytes(&value)
             .map_err(|err| serde::de::Error::custom(err.to_string()))?;
         Ok(KeyPair(key))
     }
 }
 
+impl Serialize for Signature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&hex::encode(&self.0.to_bytes()))
+        } else {
+            serializer.serialize_newtype_struct("Signature", &self.0)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Signature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            use ed25519_dalek::ed25519::signature::Signature;
+
+            let s = String::deserialize(deserializer)?;
+            let value = hex::decode(&s).map_err(|err| serde::de::Error::custom(err.to_string()))?;
+            let sig = dalek::Signature::from_bytes(&value)
+                .map_err(|err| serde::de::Error::custom(err.to_string()))?;
+            Ok(Signature(sig))
+        } else {
+            #[derive(Deserialize)]
+            #[serde(rename = "Signature")]
+            struct Foo(dalek::Signature);
+
+            let value = Foo::deserialize(deserializer)?;
+            Ok(Self(value.0))
+        }
+    }
+}
+
+impl std::fmt::Display for PublicKeyBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(&self.0[..]))
+    }
+}
+
+impl FromStr for PublicKeyBytes {
+    type Err = failure::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = hex::decode(s)?;
+        if value.len() != dalek::PUBLIC_KEY_LENGTH {
+            failure::bail!("Invalid length for hex-encoded public key");
+        }
+        let mut pubkey = [0u8; dalek::PUBLIC_KEY_LENGTH];
+        pubkey.copy_from_slice(&value[..dalek::PUBLIC_KEY_LENGTH]);
+        Ok(PublicKeyBytes(pubkey))
+    }
+}
+
+impl std::fmt::Display for AccountId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serde_json::to_string(&self.0).unwrap())
+    }
+}
+
+impl FromStr for AccountId {
+    type Err = failure::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(AccountId(serde_json::from_str(s)?))
+    }
+}
+
+impl std::fmt::Display for Signature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        let s = hex::encode(&self.0.to_bytes());
+        write!(f, "{}", s)
+    }
+}
+
 impl std::fmt::Debug for Signature {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        let s = base64::encode(&self.0);
-        write!(f, "{}", s)?;
-        Ok(())
+        write!(f, "{}", self)
     }
 }
 
 impl std::fmt::Debug for PublicKeyBytes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        let s = base64::encode(&self.0);
-        write!(f, "{}", s)?;
-        Ok(())
+        write!(f, "{}", self)
+    }
+}
+
+impl std::fmt::Debug for AccountId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(f, "{}", self)
     }
 }
 

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -40,7 +40,7 @@ pub struct ClientState<AuthorityClient> {
     /// Our offchain account id.
     account_id: AccountId,
     /// Our signature key.
-    secret: KeyPair,
+    key_pair: KeyPair,
     /// Our FastPay committee.
     committee: Committee,
     /// How to talk to this committee.
@@ -107,7 +107,7 @@ impl<A> ClientState<A> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         account_id: AccountId,
-        secret: KeyPair,
+        key_pair: KeyPair,
         committee: Committee,
         authority_clients: HashMap<AuthorityName, A>,
         next_sequence_number: SequenceNumber,
@@ -117,7 +117,7 @@ impl<A> ClientState<A> {
     ) -> Self {
         Self {
             account_id,
-            secret,
+            key_pair,
             committee,
             authority_clients,
             next_sequence_number,
@@ -509,7 +509,7 @@ where
             sequence_number: self.next_sequence_number,
             user_data,
         };
-        let order = TransferOrder::new(transfer, &self.secret);
+        let order = TransferOrder::new(transfer, &self.key_pair);
         let certificate = self
             .execute_transfer(order, /* with_confirmation */ true)
             .await?;
@@ -679,7 +679,7 @@ where
                 sequence_number: self.next_sequence_number,
                 user_data,
             };
-            let order = TransferOrder::new(transfer, &self.secret);
+            let order = TransferOrder::new(transfer, &self.key_pair);
             let new_certificate = self
                 .execute_transfer(order, /* with_confirmation */ false)
                 .await?;

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -94,8 +94,8 @@ pub enum FastPayError {
     BalanceUnderflow,
     #[fail(display = "Wrong shard used.")]
     WrongShard,
-    #[fail(display = "Invalid cross shard update.")]
-    InvalidCrossShardUpdate,
+    #[fail(display = "Invalid cross shard request.")]
+    InvalidCrossShardRequest,
     #[fail(display = "Cannot deserialize.")]
     InvalidDecoding,
     #[fail(display = "Unexpected message.")]

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -25,6 +25,8 @@ macro_rules! fp_ensure {
 /// Custom error type for FastPay.
 pub enum FastPayError {
     // Signature verification
+    #[fail(display = "Request was not signed by an authorized owner")]
+    InvalidOwner,
     #[fail(display = "Signature is not valid: {}", error)]
     InvalidSignature { error: String },
     #[fail(display = "Value was not signed by a known authority")]
@@ -59,7 +61,7 @@ pub enum FastPayError {
         display = "Cannot confirm a transfer while previous transfer orders are still pending confirmation: {:?}",
         current_sequence_number
     )]
-    MissingEalierConfirmations {
+    MissingEarlierConfirmations {
         current_sequence_number: VersionNumber,
     },
     // Synchronization validation
@@ -68,8 +70,10 @@ pub enum FastPayError {
     // Account access
     #[fail(display = "No certificate for this account and sequence number")]
     CertificateNotfound,
-    #[fail(display = "Unknown sender's account")]
-    UnknownSenderAccount,
+    #[fail(display = "Unknown sender's account {:?}", 0)]
+    UnknownSenderAccount(AccountId),
+    #[fail(display = "Unknown recipient's account {:?}", 0)]
+    UnknownRecipientAccount(AccountId),
     #[fail(display = "Signatures in a certificate must be from different authorities.")]
     CertificateAuthorityReuse,
     #[fail(display = "Sequence numbers above the maximal value are not usable for transfers.")]

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -46,6 +46,8 @@ pub enum FastPayError {
         current_balance
     )]
     InsufficientFunding { current_balance: Balance },
+    #[fail(display = "Invalid new account id: {}", 0)]
+    InvalidNewAccountId(AccountId),
     #[fail(
         display = "Cannot initiate transfer while a transfer order is still pending confirmation: {:?}",
         pending_confirmation

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -22,7 +22,7 @@ pub struct FastPaySmartContractState {
     /// Committee of this FastPay instance.
     committee: Committee,
     /// Onchain states of FastPay smart contract.
-    pub accounts: BTreeMap<FastPayAddress, AccountOnchainState>,
+    pub accounts: BTreeMap<AccountId, AccountOnchainState>,
     /// Primary coins in the smart contract.
     total_balance: Amount,
     /// The latest transaction index included in the blockchain.
@@ -78,7 +78,7 @@ impl FastPaySmartContract for FastPaySmartContractState {
         );
         let account = self
             .accounts
-            .entry(order.sender)
+            .entry(order.transfer.account_id.clone())
             .or_insert_with(AccountOnchainState::new);
         ensure!(
             account.last_redeemed < Some(transfer.sequence_number),

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -78,7 +78,7 @@ impl FastPaySmartContract for FastPaySmartContractState {
         );
         let account = self
             .accounts
-            .entry(transfer.sender)
+            .entry(order.sender)
             .or_insert_with(AccountOnchainState::new);
         ensure!(
             account.last_redeemed < Some(transfer.sequence_number),

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -74,12 +74,6 @@ impl FastPaySmartContract for FastPaySmartContractState {
         let transfer = &order.transfer;
         match &transfer.operation {
             Operation::Payment {
-                recipient: Address::FastPay(_),
-                ..
-            } => {
-                failure::bail!("Invalid redeem transaction");
-            }
-            Operation::Payment {
                 amount,
                 recipient: Address::Primary(_),
                 ..
@@ -100,6 +94,11 @@ impl FastPaySmartContract for FastPaySmartContractState {
                 self.total_balance = self.total_balance.try_sub(*amount)?;
                 // Transfer Primary coins to order.recipient
                 Ok(())
+            }
+            Operation::Payment { .. }
+            | Operation::CreateAccount { .. }
+            | Operation::ChangeOwner { .. } => {
+                failure::bail!("Invalid redeem transaction");
             }
         }
     }

--- a/fastpay_core/src/generate_format.rs
+++ b/fastpay_core/src/generate_format.rs
@@ -16,6 +16,8 @@ fn get_registry() -> Result<Registry> {
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<messages::Address>(&samples)?;
     tracer.trace_type::<messages::Operation>(&samples)?;
+    tracer.trace_type::<messages::CrossShardRequest>(&samples)?;
+    tracer.trace_type::<messages::ConfirmationOutcome>(&samples)?;
     tracer.trace_type::<error::FastPayError>(&samples)?;
     tracer.trace_type::<serialize::SerializedMessage>(&samples)?;
     tracer.registry()

--- a/fastpay_core/src/generate_format.rs
+++ b/fastpay_core/src/generate_format.rs
@@ -15,6 +15,7 @@ fn get_registry() -> Result<Registry> {
 
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<messages::Address>(&samples)?;
+    tracer.trace_type::<messages::Operation>(&samples)?;
     tracer.trace_type::<error::FastPayError>(&samples)?;
     tracer.trace_type::<serialize::SerializedMessage>(&samples)?;
     tracer.registry()

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -168,11 +168,11 @@ impl TransferOrder {
 
 impl SignedTransferOrder {
     /// Use signing key to create a signed object.
-    pub fn new(value: TransferOrder, authority: AuthorityName, secret: &KeyPair) -> Self {
-        let signature = Signature::new(&value.transfer, secret);
+    pub fn new(value: TransferOrder, key_pair: &KeyPair) -> Self {
+        let signature = Signature::new(&value.transfer, key_pair);
         Self {
             value,
-            authority,
+            authority: key_pair.public(),
             signature,
         }
     }

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -34,12 +34,19 @@ pub enum Address {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub enum Operation {
+    Payment {
+        recipient: Address,
+        amount: Amount,
+        user_data: UserData,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct Transfer {
     pub account_id: AccountId,
-    pub recipient: Address,
-    pub amount: Amount,
+    pub operation: Operation,
     pub sequence_number: SequenceNumber,
-    pub user_data: UserData,
 }
 
 #[derive(Eq, Clone, Debug, Serialize, Deserialize)]
@@ -148,6 +155,23 @@ impl TransferOrder {
             self.transfer.account_id.clone(),
             self.transfer.sequence_number,
         )
+    }
+}
+
+/// Non-testing code should make the pattern matching explicit so that
+/// we kwow where to add protocols in the future.
+#[cfg(test)]
+impl Transfer {
+    pub(crate) fn amount(&self) -> Option<Amount> {
+        match &self.operation {
+            Operation::Payment { amount, .. } => Some(*amount),
+        }
+    }
+
+    pub(crate) fn amount_mut(&mut self) -> Option<&mut Amount> {
+        match &mut self.operation {
+            Operation::Payment { amount, .. } => Some(amount),
+        }
     }
 }
 

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -40,6 +40,13 @@ pub enum Operation {
         amount: Amount,
         user_data: UserData,
     },
+    CreateAccount {
+        new_id: AccountId,
+        new_owner: AccountOwner,
+    },
+    ChangeOwner {
+        new_owner: AccountOwner,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
@@ -165,12 +172,14 @@ impl Transfer {
     pub(crate) fn amount(&self) -> Option<Amount> {
         match &self.operation {
             Operation::Payment { amount, .. } => Some(*amount),
+            _ => None,
         }
     }
 
     pub(crate) fn amount_mut(&mut self) -> Option<&mut Amount> {
         match &mut self.operation {
             Operation::Payment { amount, .. } => Some(amount),
+            _ => None,
         }
     }
 }

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -113,6 +113,7 @@ pub struct AccountInfoResponse {
     pub balance: Balance,
     pub next_sequence_number: SequenceNumber,
     pub pending_confirmation: Option<SignedTransferOrder>,
+    pub ongoing_confirmation: Option<CertifiedTransferOrder>,
     pub requested_certificate: Option<CertifiedTransferOrder>,
     pub requested_received_transfers: Vec<CertifiedTransferOrder>,
 }

--- a/fastpay_core/src/serialize.rs
+++ b/fastpay_core/src/serialize.rs
@@ -15,11 +15,12 @@ mod serialize_tests;
 pub enum SerializedMessage {
     Order(Box<TransferOrder>),
     Vote(Box<SignedTransferOrder>),
-    Cert(Box<CertifiedTransferOrder>),
-    CrossShard(Box<CertifiedTransferOrder>),
+    Confirmation(Box<CertifiedTransferOrder>),
     Error(Box<FastPayError>),
-    InfoReq(Box<AccountInfoRequest>),
-    InfoResp(Box<AccountInfoResponse>),
+    InfoRequest(Box<AccountInfoRequest>),
+    InfoResponse(Box<AccountInfoResponse>),
+    // Internal to an authority
+    CrossShardRequest(Box<CrossShardRequest>),
 }
 
 // This helper structure is only here to avoid cloning while serializing commands.
@@ -30,10 +31,11 @@ enum ShallowSerializedMessage<'a> {
     Order(&'a TransferOrder),
     Vote(&'a SignedTransferOrder),
     Cert(&'a CertifiedTransferOrder),
-    CrossShard(&'a CertifiedTransferOrder),
     Error(&'a FastPayError),
-    InfoReq(&'a AccountInfoRequest),
-    InfoResp(&'a AccountInfoResponse),
+    InfoRequest(&'a AccountInfoRequest),
+    InfoResponse(&'a AccountInfoResponse),
+    // Internal to an authority
+    CrossShardRequest(&'a CrossShardRequest),
 }
 
 fn serialize_into<T, W>(writer: W, msg: &T) -> Result<(), failure::Error>
@@ -91,15 +93,15 @@ where
 }
 
 pub fn serialize_info_request(value: &AccountInfoRequest) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::InfoReq(value))
+    serialize(&ShallowSerializedMessage::InfoRequest(value))
 }
 
 pub fn serialize_info_response(value: &AccountInfoResponse) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::InfoResp(value))
+    serialize(&ShallowSerializedMessage::InfoResponse(value))
 }
 
-pub fn serialize_cross_shard(value: &CertifiedTransferOrder) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::CrossShard(value))
+pub fn serialize_cross_shard_request(value: &CrossShardRequest) -> Vec<u8> {
+    serialize(&ShallowSerializedMessage::CrossShardRequest(value))
 }
 
 pub fn serialize_vote(value: &SignedTransferOrder) -> Vec<u8> {

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -6,10 +6,14 @@ use super::*;
 #[test]
 fn test_handle_transfer_order_bad_signature() {
     let (sender, sender_key) = get_key_pair();
-    let recipient = Address::FastPay(dbg_addr(2));
-    let mut authority_state = init_state_with_account(sender, Balance::from(5));
-    let transfer_order = init_transfer_order(sender, &sender_key, recipient, Amount::from(5));
-    let (_unknown_address, unknown_key) = get_key_pair();
+    let recipient = Address::FastPay(dbg_account(2));
+    let mut authority_state = init_state_with_accounts(vec![
+        (dbg_account(1), sender, Balance::from(5)),
+        (dbg_account(2), dbg_addr(2), Balance::from(0)),
+    ]);
+    let transfer_order =
+        init_transfer_order(dbg_account(1), &sender_key, recipient, Amount::from(5));
+    let (_, unknown_key) = get_key_pair();
     let mut bad_signature_transfer_order = transfer_order.clone();
     bad_signature_transfer_order.signature = Signature::new(&transfer_order.transfer, &unknown_key);
     assert!(authority_state
@@ -17,7 +21,7 @@ fn test_handle_transfer_order_bad_signature() {
         .is_err());
     assert!(authority_state
         .accounts
-        .get(&sender)
+        .get(&dbg_account(1))
         .unwrap()
         .pending_confirmation
         .is_none());
@@ -26,20 +30,24 @@ fn test_handle_transfer_order_bad_signature() {
 #[test]
 fn test_handle_transfer_order_zero_amount() {
     let (sender, sender_key) = get_key_pair();
-    let recipient = Address::FastPay(dbg_addr(2));
-    let mut authority_state = init_state_with_account(sender, Balance::from(5));
-    let transfer_order = init_transfer_order(sender, &sender_key, recipient, Amount::from(5));
+    let recipient = Address::FastPay(dbg_account(2));
+    let mut authority_state = init_state_with_accounts(vec![
+        (dbg_account(1), sender, Balance::from(5)),
+        (dbg_account(2), dbg_addr(2), Balance::from(0)),
+    ]);
+    let transfer_order =
+        init_transfer_order(dbg_account(1), &sender_key, recipient, Amount::from(5));
 
     // test transfer non-positive amount
     let mut zero_amount_transfer = transfer_order.transfer;
     zero_amount_transfer.amount = Amount::zero();
-    let zero_amount_transfer_order = TransferOrder::new(sender, zero_amount_transfer, &sender_key);
+    let zero_amount_transfer_order = TransferOrder::new(zero_amount_transfer, &sender_key);
     assert!(authority_state
         .handle_transfer_order(zero_amount_transfer_order)
         .is_err());
     assert!(authority_state
         .accounts
-        .get(&sender)
+        .get(&dbg_account(1))
         .unwrap()
         .pending_confirmation
         .is_none());
@@ -48,19 +56,22 @@ fn test_handle_transfer_order_zero_amount() {
 #[test]
 fn test_handle_transfer_order_unknown_sender() {
     let (sender, sender_key) = get_key_pair();
-    let recipient = Address::FastPay(dbg_addr(2));
-    let mut authority_state = init_state_with_account(sender, Balance::from(5));
-    let transfer_order = init_transfer_order(sender, &sender_key, recipient, Amount::from(5));
-    let (unknown_address, unknown_key) = get_key_pair();
+    let recipient = Address::FastPay(dbg_account(2));
+    let mut authority_state = init_state_with_accounts(vec![
+        (dbg_account(1), sender, Balance::from(5)),
+        (dbg_account(2), dbg_addr(2), Balance::from(0)),
+    ]);
+    let transfer_order =
+        init_transfer_order(dbg_account(1), &sender_key, recipient, Amount::from(5));
+    let (_, unknown_key) = get_key_pair();
 
-    let unknown_sender_transfer_order =
-        TransferOrder::new(unknown_address, transfer_order.transfer, &unknown_key);
+    let unknown_sender_transfer_order = TransferOrder::new(transfer_order.transfer, &unknown_key);
     assert!(authority_state
         .handle_transfer_order(unknown_sender_transfer_order)
         .is_err());
     assert!(authority_state
         .accounts
-        .get(&sender)
+        .get(&dbg_account(1))
         .unwrap()
         .pending_confirmation
         .is_none());
@@ -69,13 +80,19 @@ fn test_handle_transfer_order_unknown_sender() {
 #[test]
 fn test_handle_transfer_order_bad_sequence_number() {
     let (sender, sender_key) = get_key_pair();
-    let recipient = Address::FastPay(dbg_addr(2));
-    let authority_state = init_state_with_account(sender, Balance::from(5));
-    let transfer_order = init_transfer_order(sender, &sender_key, recipient, Amount::from(5));
+    let recipient = Address::FastPay(dbg_account(2));
+    let authority_state = init_state_with_accounts(vec![
+        (dbg_account(1), sender, Balance::from(5)),
+        (dbg_account(2), dbg_addr(2), Balance::from(0)),
+    ]);
+    let transfer_order =
+        init_transfer_order(dbg_account(1), &sender_key, recipient, Amount::from(5));
 
     let mut sequence_number_state = authority_state;
-    let sequence_number_state_sender_account =
-        sequence_number_state.accounts.get_mut(&sender).unwrap();
+    let sequence_number_state_sender_account = sequence_number_state
+        .accounts
+        .get_mut(&dbg_account(1))
+        .unwrap();
     sequence_number_state_sender_account.next_sequence_number =
         sequence_number_state_sender_account
             .next_sequence_number
@@ -86,7 +103,7 @@ fn test_handle_transfer_order_bad_sequence_number() {
         .is_err());
     assert!(sequence_number_state
         .accounts
-        .get(&sender)
+        .get(&dbg_account(1))
         .unwrap()
         .pending_confirmation
         .is_none());
@@ -95,15 +112,19 @@ fn test_handle_transfer_order_bad_sequence_number() {
 #[test]
 fn test_handle_transfer_order_exceed_balance() {
     let (sender, sender_key) = get_key_pair();
-    let recipient = Address::FastPay(dbg_addr(2));
-    let mut authority_state = init_state_with_account(sender, Balance::from(5));
-    let transfer_order = init_transfer_order(sender, &sender_key, recipient, Amount::from(1000));
+    let recipient = Address::FastPay(dbg_account(2));
+    let mut authority_state = init_state_with_accounts(vec![
+        (dbg_account(1), sender, Balance::from(5)),
+        (dbg_account(2), dbg_addr(2), Balance::from(0)),
+    ]);
+    let transfer_order =
+        init_transfer_order(dbg_account(1), &sender_key, recipient, Amount::from(1000));
     assert!(authority_state
         .handle_transfer_order(transfer_order)
         .is_err());
     assert!(authority_state
         .accounts
-        .get(&sender)
+        .get(&dbg_account(1))
         .unwrap()
         .pending_confirmation
         .is_none());
@@ -112,16 +133,20 @@ fn test_handle_transfer_order_exceed_balance() {
 #[test]
 fn test_handle_transfer_order_ok() {
     let (sender, sender_key) = get_key_pair();
-    let recipient = Address::FastPay(dbg_addr(2));
-    let mut authority_state = init_state_with_account(sender, Balance::from(5));
-    let transfer_order = init_transfer_order(sender, &sender_key, recipient, Amount::from(5));
+    let recipient = Address::FastPay(dbg_account(2));
+    let mut authority_state = init_state_with_accounts(vec![
+        (dbg_account(1), sender, Balance::from(5)),
+        (dbg_account(2), dbg_addr(2), Balance::from(0)),
+    ]);
+    let transfer_order =
+        init_transfer_order(dbg_account(1), &sender_key, recipient, Amount::from(5));
 
     let account_info = authority_state
         .handle_transfer_order(transfer_order)
         .unwrap();
     let pending_confirmation = authority_state
         .accounts
-        .get(&sender)
+        .get(&dbg_account(1))
         .unwrap()
         .pending_confirmation
         .clone()
@@ -135,9 +160,13 @@ fn test_handle_transfer_order_ok() {
 #[test]
 fn test_handle_transfer_order_double_spend() {
     let (sender, sender_key) = get_key_pair();
-    let recipient = Address::FastPay(dbg_addr(2));
-    let mut authority_state = init_state_with_account(sender, Balance::from(5));
-    let transfer_order = init_transfer_order(sender, &sender_key, recipient, Amount::from(5));
+    let recipient = Address::FastPay(dbg_account(2));
+    let mut authority_state = init_state_with_accounts(vec![
+        (dbg_account(1), sender, Balance::from(5)),
+        (dbg_account(2), dbg_addr(2), Balance::from(0)),
+    ]);
+    let transfer_order =
+        init_transfer_order(dbg_account(1), &sender_key, recipient, Amount::from(5));
 
     let signed_order = authority_state
         .handle_transfer_order(transfer_order.clone())
@@ -150,13 +179,13 @@ fn test_handle_transfer_order_double_spend() {
 
 #[test]
 fn test_handle_confirmation_order_unknown_sender() {
-    let recipient = dbg_addr(2);
-    let (sender, sender_key) = get_key_pair();
-    let mut authority_state = init_state();
+    let (_, sender_key) = get_key_pair();
+    let mut authority_state =
+        init_state_with_accounts(vec![(dbg_account(2), dbg_addr(2), Balance::from(0))]);
     let certified_transfer_order = init_certified_transfer_order(
-        sender,
+        dbg_account(1),
         &sender_key,
-        Address::FastPay(recipient),
+        Address::FastPay(dbg_account(2)),
         Amount::from(5),
         &authority_state,
     );
@@ -164,30 +193,32 @@ fn test_handle_confirmation_order_unknown_sender() {
     assert!(authority_state
         .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order))
         .is_ok());
-    assert!(authority_state.accounts.get(&recipient).is_some());
+    assert!(authority_state.accounts.get(&dbg_account(2)).is_some());
 }
 
 #[test]
 fn test_handle_confirmation_order_bad_sequence_number() {
     let (sender, sender_key) = get_key_pair();
-    let recipient = dbg_addr(2);
-    let mut authority_state = init_state_with_account(sender, Balance::from(5));
-    let sender_account = authority_state.accounts.get_mut(&sender).unwrap();
+    let mut authority_state = init_state_with_accounts(vec![
+        (dbg_account(1), sender, Balance::from(5)),
+        (dbg_account(2), dbg_addr(2), Balance::from(0)),
+    ]);
+    let sender_account = authority_state.accounts.get_mut(&dbg_account(1)).unwrap();
     sender_account.next_sequence_number = sender_account.next_sequence_number.increment().unwrap();
     // let old_account = sender_account;
 
     let old_balance;
     let old_seq_num;
     {
-        let old_account = authority_state.accounts.get_mut(&sender).unwrap();
+        let old_account = authority_state.accounts.get_mut(&dbg_account(1)).unwrap();
         old_balance = old_account.balance;
         old_seq_num = old_account.next_sequence_number;
     }
 
     let certified_transfer_order = init_certified_transfer_order(
-        sender,
+        dbg_account(1),
         &sender_key,
-        Address::FastPay(recipient),
+        Address::FastPay(dbg_account(2)),
         Amount::from(5),
         &authority_state,
     );
@@ -195,82 +226,82 @@ fn test_handle_confirmation_order_bad_sequence_number() {
     assert!(authority_state
         .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order))
         .is_ok());
-    let new_account = authority_state.accounts.get_mut(&sender).unwrap();
+    let new_account = authority_state.accounts.get_mut(&dbg_account(1)).unwrap();
     assert_eq!(old_balance, new_account.balance);
     assert_eq!(old_seq_num, new_account.next_sequence_number);
     assert_eq!(new_account.confirmed_log, Vec::new());
-    assert!(authority_state.accounts.get(&recipient).is_none());
 }
 
 #[test]
 fn test_handle_confirmation_order_exceed_balance() {
     let (sender, sender_key) = get_key_pair();
-    let recipient = dbg_addr(2);
-    let mut authority_state = init_state_with_account(sender, Balance::from(5));
+    let mut authority_state = init_state_with_accounts(vec![
+        (dbg_account(1), sender, Balance::from(5)),
+        (dbg_account(2), dbg_addr(2), Balance::from(0)),
+    ]);
 
     let certified_transfer_order = init_certified_transfer_order(
-        sender,
+        dbg_account(1),
         &sender_key,
-        Address::FastPay(recipient),
+        Address::FastPay(dbg_account(2)),
         Amount::from(1000),
         &authority_state,
     );
     assert!(authority_state
         .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order))
         .is_ok());
-    let new_account = authority_state.accounts.get(&sender).unwrap();
+    let new_account = authority_state.accounts.get(&dbg_account(1)).unwrap();
     assert_eq!(Balance::from(-995), new_account.balance);
     assert_eq!(SequenceNumber::from(1), new_account.next_sequence_number);
     assert_eq!(new_account.confirmed_log.len(), 1);
-    assert!(authority_state.accounts.get(&recipient).is_some());
+    assert!(authority_state.accounts.get(&dbg_account(2)).is_some());
 }
 
 #[test]
 fn test_handle_confirmation_order_receiver_balance_overflow() {
     let (sender, sender_key) = get_key_pair();
-    let (recipient, _) = get_key_pair();
     let mut authority_state = init_state_with_accounts(vec![
-        (sender, Balance::from(1)),
-        (recipient, Balance::max()),
+        (dbg_account(1), sender, Balance::from(1)),
+        (dbg_account(2), dbg_addr(2), Balance::max()),
     ]);
 
     let certified_transfer_order = init_certified_transfer_order(
-        sender,
+        dbg_account(1),
         &sender_key,
-        Address::FastPay(recipient),
+        Address::FastPay(dbg_account(2)),
         Amount::from(1),
         &authority_state,
     );
     assert!(authority_state
         .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order))
         .is_ok());
-    let new_sender_account = authority_state.accounts.get(&sender).unwrap();
+    let new_sender_account = authority_state.accounts.get(&dbg_account(1)).unwrap();
     assert_eq!(Balance::from(0), new_sender_account.balance);
     assert_eq!(
         SequenceNumber::from(1),
         new_sender_account.next_sequence_number
     );
     assert_eq!(new_sender_account.confirmed_log.len(), 1);
-    let new_recipient_account = authority_state.accounts.get(&recipient).unwrap();
+    let new_recipient_account = authority_state.accounts.get(&dbg_account(2)).unwrap();
     assert_eq!(Balance::max(), new_recipient_account.balance);
 }
 
 #[test]
 fn test_handle_confirmation_order_receiver_equal_sender() {
-    let (address, key) = get_key_pair();
-    let mut authority_state = init_state_with_account(address, Balance::from(1));
+    let (name, key) = get_key_pair();
+    let mut authority_state = init_state_with_account(dbg_account(1), name, Balance::from(1));
 
     let certified_transfer_order = init_certified_transfer_order(
-        address,
+        dbg_account(1),
         &key,
-        Address::FastPay(address),
+        Address::FastPay(dbg_account(1)),
         Amount::from(10),
         &authority_state,
     );
     assert!(authority_state
         .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order))
         .is_ok());
-    let account = authority_state.accounts.get(&address).unwrap();
+    let account = authority_state.accounts.get(&dbg_account(1)).unwrap();
     assert_eq!(Balance::from(1), account.balance);
     assert_eq!(SequenceNumber::from(1), account.next_sequence_number);
     assert_eq!(account.confirmed_log.len(), 1);
@@ -278,21 +309,21 @@ fn test_handle_confirmation_order_receiver_equal_sender() {
 
 #[test]
 fn test_handle_cross_shard_recipient_commit() {
-    let (sender, sender_key) = get_key_pair();
-    let (recipient, _) = get_key_pair();
+    let (_, sender_key) = get_key_pair();
     // Sender has no account on this shard.
-    let mut authority_state = init_state_with_account(recipient, Balance::from(1));
+    let mut authority_state =
+        init_state_with_accounts(vec![(dbg_account(2), dbg_addr(2), Balance::from(1))]);
     let certified_transfer_order = init_certified_transfer_order(
-        sender,
+        dbg_account(1),
         &sender_key,
-        Address::FastPay(recipient),
+        Address::FastPay(dbg_account(2)),
         Amount::from(10),
         &authority_state,
     );
     assert!(authority_state
         .handle_cross_shard_recipient_commit(certified_transfer_order)
         .is_ok());
-    let account = authority_state.accounts.get(&recipient).unwrap();
+    let account = authority_state.accounts.get(&dbg_account(2)).unwrap();
     assert_eq!(Balance::from(11), account.balance);
     assert_eq!(SequenceNumber::from(0), account.next_sequence_number);
     assert_eq!(account.confirmed_log.len(), 0);
@@ -301,17 +332,19 @@ fn test_handle_cross_shard_recipient_commit() {
 #[test]
 fn test_handle_confirmation_order_ok() {
     let (sender, sender_key) = get_key_pair();
-    let recipient = dbg_addr(2);
-    let mut authority_state = init_state_with_account(sender, Balance::from(5));
+    let mut authority_state = init_state_with_accounts(vec![
+        (dbg_account(1), sender, Balance::from(5)),
+        (dbg_account(2), dbg_addr(2), Balance::from(0)),
+    ]);
     let certified_transfer_order = init_certified_transfer_order(
-        sender,
+        dbg_account(1),
         &sender_key,
-        Address::FastPay(recipient),
+        Address::FastPay(dbg_account(2)),
         Amount::from(5),
         &authority_state,
     );
 
-    let old_account = authority_state.accounts.get_mut(&sender).unwrap();
+    let old_account = authority_state.accounts.get_mut(&dbg_account(1)).unwrap();
     let mut next_sequence_number = old_account.next_sequence_number;
     next_sequence_number = next_sequence_number.increment().unwrap();
     let mut remaining_balance = old_account.balance;
@@ -322,23 +355,27 @@ fn test_handle_confirmation_order_ok() {
     let (info, _) = authority_state
         .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order.clone()))
         .unwrap();
-    assert_eq!(sender, info.sender);
+    assert_eq!(dbg_account(1), info.account_id);
     assert_eq!(remaining_balance, info.balance);
     assert_eq!(next_sequence_number, info.next_sequence_number);
     assert_eq!(None, info.pending_confirmation);
     assert_eq!(
-        authority_state.accounts.get(&sender).unwrap().confirmed_log,
+        authority_state
+            .accounts
+            .get(&dbg_account(1))
+            .unwrap()
+            .confirmed_log,
         vec![certified_transfer_order.clone()]
     );
 
-    let recipient_account = authority_state.accounts.get(&recipient).unwrap();
+    let recipient_account = authority_state.accounts.get(&dbg_account(2)).unwrap();
     assert_eq!(
         recipient_account.balance,
         certified_transfer_order.value.transfer.amount.into()
     );
 
     let info_request = AccountInfoRequest {
-        sender: recipient,
+        account_id: dbg_account(2),
         request_sequence_number: None,
         request_received_transfers_excluding_first_nth: Some(0),
     };
@@ -357,27 +394,29 @@ fn test_handle_confirmation_order_ok() {
 
 #[test]
 fn test_handle_primary_synchronization_order_update() {
-    let mut state = init_state();
+    let (owner, _) = get_key_pair();
+    let account_id = dbg_account(1);
+    let mut state = init_state_with_accounts(vec![(account_id.clone(), owner, Balance::from(0))]);
     let mut updated_transaction_index = state.last_transaction_index;
-    let address = dbg_addr(1);
-    let order = init_primary_synchronization_order(address);
+    let order = init_primary_synchronization_order(account_id.clone());
 
     assert!(state
         .handle_primary_synchronization_order(order.clone())
         .is_ok());
     updated_transaction_index = updated_transaction_index.increment().unwrap();
     assert_eq!(state.last_transaction_index, updated_transaction_index);
-    let account = state.accounts.get(&address).unwrap();
+    let account = state.accounts.get(&account_id).unwrap();
     assert_eq!(account.balance, order.amount.into());
     assert_eq!(state.accounts.len(), 1);
 }
 
 #[test]
 fn test_handle_primary_synchronization_order_double_spend() {
-    let mut state = init_state();
+    let (owner, _) = get_key_pair();
+    let account_id = dbg_account(1);
+    let mut state = init_state_with_accounts(vec![(account_id.clone(), owner, Balance::from(0))]);
     let mut updated_transaction_index = state.last_transaction_index;
-    let address = dbg_addr(1);
-    let order = init_primary_synchronization_order(address);
+    let order = init_primary_synchronization_order(account_id.clone());
 
     assert!(state
         .handle_primary_synchronization_order(order.clone())
@@ -388,15 +427,15 @@ fn test_handle_primary_synchronization_order_double_spend() {
         .handle_primary_synchronization_order(order.clone())
         .is_ok());
     assert_eq!(state.last_transaction_index, updated_transaction_index);
-    let account = state.accounts.get(&address).unwrap();
+    let account = state.accounts.get(&account_id).unwrap();
     assert_eq!(account.balance, order.amount.into());
     assert_eq!(state.accounts.len(), 1);
 }
 
 #[test]
 fn test_account_state_ok() {
-    let sender = dbg_addr(1);
-    let authority_state = init_state_with_account(sender, Balance::from(5));
+    let sender = dbg_account(1);
+    let authority_state = init_state_with_account(sender.clone(), dbg_addr(1), Balance::from(5));
     assert_eq!(
         authority_state.accounts.get(&sender).unwrap(),
         authority_state.account_state(&sender).unwrap()
@@ -405,10 +444,10 @@ fn test_account_state_ok() {
 
 #[test]
 fn test_account_state_unknown_account() {
-    let sender = dbg_addr(1);
-    let unknown_address = dbg_addr(99);
-    let authority_state = init_state_with_account(sender, Balance::from(5));
-    assert!(authority_state.account_state(&unknown_address).is_err());
+    let sender = dbg_account(1);
+    let unknown_account_id = dbg_account(99);
+    let authority_state = init_state_with_account(sender, dbg_addr(1), Balance::from(5));
+    assert!(authority_state.account_state(&unknown_account_id).is_err());
 }
 
 #[test]
@@ -416,9 +455,9 @@ fn test_get_shards() {
     let num_shards = 16u32;
     let mut found = vec![false; num_shards as usize];
     let mut left = num_shards;
+    let mut i = 1;
     loop {
-        let (address, _) = get_key_pair();
-        let shard = AuthorityState::get_shard(num_shards, &address) as usize;
+        let shard = AuthorityState::get_shard(num_shards, &dbg_account(i)) as usize;
         println!("found {}", shard);
         if !found[shard] {
             found[shard] = true;
@@ -427,6 +466,7 @@ fn test_get_shards() {
                 break;
             }
         }
+        i += 1;
     }
 }
 
@@ -434,61 +474,59 @@ fn test_get_shards() {
 
 #[cfg(test)]
 fn init_state() -> AuthorityState {
-    let (authority_address, authority_key) = get_key_pair();
+    let (authority_name, authority_key) = get_key_pair();
     let mut authorities = BTreeMap::new();
-    authorities.insert(
-        /* address */ authority_address,
-        /* voting right */ 1,
-    );
+    authorities.insert(authority_name, /* voting right */ 1);
     let committee = Committee::new(authorities);
-    AuthorityState::new(committee, authority_address, authority_key)
+    AuthorityState::new(committee, authority_name, authority_key)
 }
 
 #[cfg(test)]
-fn init_state_with_accounts<I: IntoIterator<Item = (FastPayAddress, Balance)>>(
+fn init_state_with_accounts<I: IntoIterator<Item = (AccountId, AccountOwner, Balance)>>(
     balances: I,
 ) -> AuthorityState {
     let mut state = init_state();
-    for (address, balance) in balances {
+    for (id, owner, balance) in balances {
         let account = state
             .accounts
-            .entry(address)
-            .or_insert_with(AccountOffchainState::new);
+            .entry(id)
+            .or_insert_with(|| AccountOffchainState::new(owner));
         account.balance = balance;
     }
     state
 }
 
 #[cfg(test)]
-fn init_state_with_account(address: FastPayAddress, balance: Balance) -> AuthorityState {
-    init_state_with_accounts(std::iter::once((address, balance)))
+fn init_state_with_account(id: AccountId, owner: AccountOwner, balance: Balance) -> AuthorityState {
+    init_state_with_accounts(std::iter::once((id, owner, balance)))
 }
 
 #[cfg(test)]
 fn init_transfer_order(
-    sender: FastPayAddress,
+    account_id: AccountId,
     secret: &KeyPair,
     recipient: Address,
     amount: Amount,
 ) -> TransferOrder {
     let transfer = Transfer {
+        account_id,
         recipient,
         amount,
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    TransferOrder::new(sender, transfer, secret)
+    TransferOrder::new(transfer, secret)
 }
 
 #[cfg(test)]
 fn init_certified_transfer_order(
-    sender: FastPayAddress,
+    account_id: AccountId,
     secret: &KeyPair,
     recipient: Address,
     amount: Amount,
     authority_state: &AuthorityState,
 ) -> CertifiedTransferOrder {
-    let transfer_order = init_transfer_order(sender, secret, recipient, amount);
+    let transfer_order = init_transfer_order(account_id, secret, recipient, amount);
     let vote = SignedTransferOrder::new(
         transfer_order.clone(),
         authority_state.name,
@@ -503,7 +541,7 @@ fn init_certified_transfer_order(
 }
 
 #[cfg(test)]
-fn init_primary_synchronization_order(recipient: FastPayAddress) -> PrimarySynchronizationOrder {
+fn init_primary_synchronization_order(recipient: AccountId) -> PrimarySynchronizationOrder {
     let mut transaction_index = VersionNumber::new();
     transaction_index = transaction_index.increment().unwrap();
     PrimarySynchronizationOrder {

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -33,7 +33,7 @@ fn test_handle_transfer_order_zero_amount() {
     // test transfer non-positive amount
     let mut zero_amount_transfer = transfer_order.transfer;
     zero_amount_transfer.amount = Amount::zero();
-    let zero_amount_transfer_order = TransferOrder::new(zero_amount_transfer, &sender_key);
+    let zero_amount_transfer_order = TransferOrder::new(sender, zero_amount_transfer, &sender_key);
     assert!(authority_state
         .handle_transfer_order(zero_amount_transfer_order)
         .is_err());
@@ -53,9 +53,8 @@ fn test_handle_transfer_order_unknown_sender() {
     let transfer_order = init_transfer_order(sender, &sender_key, recipient, Amount::from(5));
     let (unknown_address, unknown_key) = get_key_pair();
 
-    let mut unknown_sender_transfer = transfer_order.transfer;
-    unknown_sender_transfer.sender = unknown_address;
-    let unknown_sender_transfer_order = TransferOrder::new(unknown_sender_transfer, &unknown_key);
+    let unknown_sender_transfer_order =
+        TransferOrder::new(unknown_address, transfer_order.transfer, &unknown_key);
     assert!(authority_state
         .handle_transfer_order(unknown_sender_transfer_order)
         .is_err());
@@ -473,13 +472,12 @@ fn init_transfer_order(
     amount: Amount,
 ) -> TransferOrder {
     let transfer = Transfer {
-        sender,
         recipient,
         amount,
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    TransferOrder::new(transfer, secret)
+    TransferOrder::new(sender, transfer, secret)
 }
 
 #[cfg(test)]

--- a/fastpay_core/src/unit_tests/base_types_tests.rs
+++ b/fastpay_core/src/unit_tests/base_types_tests.rs
@@ -17,14 +17,16 @@ impl BcsSignable for Bar {}
 
 #[test]
 fn test_signatures() {
-    let (addr1, sec1) = get_key_pair();
-    let (addr2, _sec2) = get_key_pair();
+    let key1 = get_key_pair();
+    let addr1 = key1.public();
+    let key2 = get_key_pair();
+    let addr2 = key2.public();
 
     let foo = Foo("hello".into());
     let foox = Foo("hellox".into());
     let bar = Bar("hello".into());
 
-    let s = Signature::new(&foo, &sec1);
+    let s = Signature::new(&foo, &key1);
     assert!(s.check(&foo, addr1).is_ok());
     assert!(s.check(&foo, addr2).is_err());
     assert!(s.check(&foox, addr1).is_err());

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -63,14 +63,15 @@ fn init_local_authorities(
     let mut voting_rights = BTreeMap::new();
     for _ in 0..count {
         let key_pair = get_key_pair();
-        voting_rights.insert(key_pair.0, 1);
+        voting_rights.insert(key_pair.public(), 1);
         key_pairs.push(key_pair);
     }
     let committee = Committee::new(voting_rights);
 
     let mut clients = HashMap::new();
-    for (name, secret) in key_pairs {
-        let state = AuthorityState::new(committee.clone(), name, secret);
+    for key_pair in key_pairs {
+        let name = key_pair.public();
+        let state = AuthorityState::new(committee.clone(), name, key_pair);
         clients.insert(name, LocalAuthorityClient::new(state));
     }
     (clients, committee)
@@ -84,7 +85,7 @@ fn init_local_authorities_bad_1(
     let mut voting_rights = BTreeMap::new();
     for i in 0..count {
         let key_pair = get_key_pair();
-        voting_rights.insert(key_pair.0, 1);
+        voting_rights.insert(key_pair.public(), 1);
         if i + 1 < (count + 2) / 3 {
             // init 1 authority with a bad keypair
             key_pairs.push(get_key_pair());
@@ -95,8 +96,9 @@ fn init_local_authorities_bad_1(
     let committee = Committee::new(voting_rights);
 
     let mut clients = HashMap::new();
-    for (name, secret) in key_pairs {
-        let state = AuthorityState::new(committee.clone(), name, secret);
+    for key_pair in key_pairs {
+        let name = key_pair.public();
+        let state = AuthorityState::new(committee.clone(), name, key_pair);
         clients.insert(name, LocalAuthorityClient::new(state));
     }
     (clients, committee)
@@ -108,10 +110,10 @@ fn make_client(
     authority_clients: HashMap<AuthorityName, LocalAuthorityClient>,
     committee: Committee,
 ) -> ClientState<LocalAuthorityClient> {
-    let (_, secret) = get_key_pair();
+    let key_pair = get_key_pair();
     ClientState::new(
         account_id,
-        secret,
+        key_pair,
         committee,
         authority_clients,
         SequenceNumber::new(),
@@ -149,14 +151,14 @@ fn init_local_client_state(balances: Vec<i128>) -> ClientState<LocalAuthorityCli
     fund_account(
         &mut authority_clients,
         client1.account_id.clone(),
-        client1.secret.public(),
+        client1.key_pair.public(),
         balances,
     );
     let client2 = make_client(dbg_account(2), authority_clients.clone(), committee);
     fund_account(
         &mut authority_clients,
         client2.account_id.clone(),
-        client2.secret.public(),
+        client2.key_pair.public(),
         zeroes,
     );
     client1
@@ -172,14 +174,14 @@ fn init_local_client_state_with_bad_authority(
     fund_account(
         &mut authority_clients,
         client1.account_id.clone(),
-        client1.secret.public(),
+        client1.key_pair.public(),
         balances,
     );
     let client2 = make_client(dbg_account(2), authority_clients.clone(), committee);
     fund_account(
         &mut authority_clients,
         client2.account_id.clone(),
-        client2.secret.public(),
+        client2.key_pair.public(),
         zeroes,
     );
     client1
@@ -276,13 +278,13 @@ fn test_bidirectional_transfer() {
     fund_account(
         &mut authority_clients,
         client1.account_id.clone(),
-        client1.secret.public(),
+        client1.key_pair.public(),
         vec![2, 3, 4, 4],
     );
     fund_account(
         &mut authority_clients,
         client2.account_id.clone(),
-        client2.secret.public(),
+        client2.key_pair.public(),
         vec![0; 4],
     );
     // Update client1's local balance accordingly.
@@ -364,13 +366,13 @@ fn test_receiving_unconfirmed_transfer() {
     fund_account(
         &mut authority_clients,
         client1.account_id.clone(),
-        client1.secret.public(),
+        client1.key_pair.public(),
         vec![2, 3, 4, 4],
     );
     fund_account(
         &mut authority_clients,
         client2.account_id.clone(),
-        client2.secret.public(),
+        client2.key_pair.public(),
         vec![0; 4],
     );
 
@@ -413,19 +415,19 @@ fn test_receiving_unconfirmed_transfer_with_lagging_sender_balances() {
     fund_account(
         &mut authority_clients,
         client0.account_id.clone(),
-        client0.secret.public(),
+        client0.key_pair.public(),
         vec![2, 3, 4, 4],
     );
     fund_account(
         &mut authority_clients,
         client1.account_id.clone(),
-        client1.secret.public(),
+        client1.key_pair.public(),
         vec![0; 4],
     );
     fund_account(
         &mut authority_clients,
         client2.account_id.clone(),
-        client2.secret.public(),
+        client2.key_pair.public(),
         vec![0; 4],
     );
 

--- a/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
+++ b/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
@@ -58,11 +58,7 @@ fn test_handle_redeem_transaction_ok() {
     assert!(contract_state
         .handle_redeem_transaction(redeem_transaction.clone())
         .is_ok());
-    let sender = redeem_transaction
-        .transfer_certificate
-        .value
-        .transfer
-        .sender;
+    let sender = redeem_transaction.transfer_certificate.value.sender;
     let amount = redeem_transaction
         .transfer_certificate
         .value
@@ -161,13 +157,12 @@ fn init_redeem_transaction(
 ) -> RedeemTransaction {
     let (sender_address, sender_key) = get_key_pair();
     let primary_transfer = Transfer {
-        sender: sender_address,
         recipient: Address::Primary(dbg_addr(2)),
         amount: Amount::from(3),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(primary_transfer, &sender_key);
+    let order = TransferOrder::new(sender_address, primary_transfer, &sender_key);
     let vote = SignedTransferOrder::new(order.clone(), name, &secret);
     let mut builder = SignatureAggregator::try_new(order, &committee).unwrap();
     let certificate = builder

--- a/fastpay_core/src/unit_tests/messages_tests.rs
+++ b/fastpay_core/src/unit_tests/messages_tests.rs
@@ -19,10 +19,12 @@ fn test_signed_values() {
 
     let transfer = Transfer {
         account_id: dbg_account(1),
-        recipient: Address::FastPay(dbg_account(2)),
-        amount: Amount::from(1),
+        operation: Operation::Payment {
+            recipient: Address::FastPay(dbg_account(2)),
+            amount: Amount::from(1),
+            user_data: UserData::default(),
+        },
         sequence_number: SequenceNumber::new(),
-        user_data: UserData::default(),
     };
     let order = TransferOrder::new(transfer.clone(), &key1);
     let mut bad_order = TransferOrder::new(transfer, &key2);
@@ -56,10 +58,12 @@ fn test_certificates() {
 
     let transfer = Transfer {
         account_id: dbg_account(1),
-        recipient: Address::FastPay(dbg_account(1)),
-        amount: Amount::from(1),
+        operation: Operation::Payment {
+            recipient: Address::FastPay(dbg_account(1)),
+            amount: Amount::from(1),
+            user_data: UserData::default(),
+        },
         sequence_number: SequenceNumber::new(),
-        user_data: UserData::default(),
     };
     let order = TransferOrder::new(transfer.clone(), &key1);
     let mut bad_order = TransferOrder::new(transfer, &key2);

--- a/fastpay_core/src/unit_tests/messages_tests.rs
+++ b/fastpay_core/src/unit_tests/messages_tests.rs
@@ -7,12 +7,14 @@ use std::collections::BTreeMap;
 #[test]
 fn test_signed_values() {
     let mut authorities = BTreeMap::new();
-    let (name1, sec1) = get_key_pair();
-    let (name2, sec2) = get_key_pair();
-    let (name3, sec3) = get_key_pair();
+    let key1 = get_key_pair();
+    let key2 = get_key_pair();
+    let key3 = get_key_pair();
+    let name1 = key1.public();
+    let name2 = key2.public();
 
-    authorities.insert(/* name */ name1, /* voting right */ 1);
-    authorities.insert(/* name */ name2, /* voting right */ 0);
+    authorities.insert(name1, /* voting right */ 1);
+    authorities.insert(name2, /* voting right */ 0);
     let committee = Committee::new(authorities);
 
     let transfer = Transfer {
@@ -22,32 +24,34 @@ fn test_signed_values() {
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(transfer.clone(), &sec1);
-    let mut bad_order = TransferOrder::new(transfer, &sec2);
+    let order = TransferOrder::new(transfer.clone(), &key1);
+    let mut bad_order = TransferOrder::new(transfer, &key2);
     bad_order.owner = name1;
 
-    let v = SignedTransferOrder::new(order.clone(), name1, &sec1);
+    let v = SignedTransferOrder::new(order.clone(), &key1);
     assert!(v.check(&committee).is_ok());
 
-    let v = SignedTransferOrder::new(order.clone(), name2, &sec2);
+    let v = SignedTransferOrder::new(order.clone(), &key2);
     assert!(v.check(&committee).is_err());
 
-    let v = SignedTransferOrder::new(order, name3, &sec3);
+    let v = SignedTransferOrder::new(order, &key3);
     assert!(v.check(&committee).is_err());
 
-    let v = SignedTransferOrder::new(bad_order, name1, &sec1);
+    let v = SignedTransferOrder::new(bad_order, &key1);
     assert!(v.check(&committee).is_err());
 }
 
 #[test]
 fn test_certificates() {
-    let (name1, sec1) = get_key_pair();
-    let (name2, sec2) = get_key_pair();
-    let (name3, sec3) = get_key_pair();
+    let key1 = get_key_pair();
+    let key2 = get_key_pair();
+    let key3 = get_key_pair();
+    let name1 = key1.public();
+    let name2 = key2.public();
 
     let mut authorities = BTreeMap::new();
-    authorities.insert(/* name */ name1, /* voting right */ 1);
-    authorities.insert(/* name */ name2, /* voting right */ 1);
+    authorities.insert(name1, /* voting right */ 1);
+    authorities.insert(name2, /* voting right */ 1);
     let committee = Committee::new(authorities);
 
     let transfer = Transfer {
@@ -57,13 +61,13 @@ fn test_certificates() {
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(transfer.clone(), &sec1);
-    let mut bad_order = TransferOrder::new(transfer, &sec2);
+    let order = TransferOrder::new(transfer.clone(), &key1);
+    let mut bad_order = TransferOrder::new(transfer, &key2);
     bad_order.owner = name1;
 
-    let v1 = SignedTransferOrder::new(order.clone(), name1, &sec1);
-    let v2 = SignedTransferOrder::new(order.clone(), name2, &sec2);
-    let v3 = SignedTransferOrder::new(order.clone(), name3, &sec3);
+    let v1 = SignedTransferOrder::new(order.clone(), &key1);
+    let v2 = SignedTransferOrder::new(order.clone(), &key2);
+    let v3 = SignedTransferOrder::new(order.clone(), &key3);
 
     let mut builder = SignatureAggregator::try_new(order.clone(), &committee).unwrap();
     assert!(builder

--- a/fastpay_core/src/unit_tests/messages_tests.rs
+++ b/fastpay_core/src/unit_tests/messages_tests.rs
@@ -7,59 +7,63 @@ use std::collections::BTreeMap;
 #[test]
 fn test_signed_values() {
     let mut authorities = BTreeMap::new();
-    let (a1, sec1) = get_key_pair();
-    let (a2, sec2) = get_key_pair();
-    let (a3, sec3) = get_key_pair();
+    let (name1, sec1) = get_key_pair();
+    let (name2, sec2) = get_key_pair();
+    let (name3, sec3) = get_key_pair();
 
-    authorities.insert(/* address */ a1, /* voting right */ 1);
-    authorities.insert(/* address */ a2, /* voting right */ 0);
+    authorities.insert(/* name */ name1, /* voting right */ 1);
+    authorities.insert(/* name */ name2, /* voting right */ 0);
     let committee = Committee::new(authorities);
 
     let transfer = Transfer {
-        recipient: Address::FastPay(a2),
+        account_id: dbg_account(1),
+        recipient: Address::FastPay(dbg_account(2)),
         amount: Amount::from(1),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(a1, transfer.clone(), &sec1);
-    let bad_order = TransferOrder::new(a1, transfer, &sec2);
+    let order = TransferOrder::new(transfer.clone(), &sec1);
+    let mut bad_order = TransferOrder::new(transfer, &sec2);
+    bad_order.owner = name1;
 
-    let v = SignedTransferOrder::new(order.clone(), a1, &sec1);
+    let v = SignedTransferOrder::new(order.clone(), name1, &sec1);
     assert!(v.check(&committee).is_ok());
 
-    let v = SignedTransferOrder::new(order.clone(), a2, &sec2);
+    let v = SignedTransferOrder::new(order.clone(), name2, &sec2);
     assert!(v.check(&committee).is_err());
 
-    let v = SignedTransferOrder::new(order, a3, &sec3);
+    let v = SignedTransferOrder::new(order, name3, &sec3);
     assert!(v.check(&committee).is_err());
 
-    let v = SignedTransferOrder::new(bad_order, a1, &sec1);
+    let v = SignedTransferOrder::new(bad_order, name1, &sec1);
     assert!(v.check(&committee).is_err());
 }
 
 #[test]
 fn test_certificates() {
-    let (a1, sec1) = get_key_pair();
-    let (a2, sec2) = get_key_pair();
-    let (a3, sec3) = get_key_pair();
+    let (name1, sec1) = get_key_pair();
+    let (name2, sec2) = get_key_pair();
+    let (name3, sec3) = get_key_pair();
 
     let mut authorities = BTreeMap::new();
-    authorities.insert(/* address */ a1, /* voting right */ 1);
-    authorities.insert(/* address */ a2, /* voting right */ 1);
+    authorities.insert(/* name */ name1, /* voting right */ 1);
+    authorities.insert(/* name */ name2, /* voting right */ 1);
     let committee = Committee::new(authorities);
 
     let transfer = Transfer {
-        recipient: Address::FastPay(a2),
+        account_id: dbg_account(1),
+        recipient: Address::FastPay(dbg_account(1)),
         amount: Amount::from(1),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(a1, transfer.clone(), &sec1);
-    let bad_order = TransferOrder::new(a1, transfer, &sec2);
+    let order = TransferOrder::new(transfer.clone(), &sec1);
+    let mut bad_order = TransferOrder::new(transfer, &sec2);
+    bad_order.owner = name1;
 
-    let v1 = SignedTransferOrder::new(order.clone(), a1, &sec1);
-    let v2 = SignedTransferOrder::new(order.clone(), a2, &sec2);
-    let v3 = SignedTransferOrder::new(order.clone(), a3, &sec3);
+    let v1 = SignedTransferOrder::new(order.clone(), name1, &sec1);
+    let v2 = SignedTransferOrder::new(order.clone(), name2, &sec2);
+    let v3 = SignedTransferOrder::new(order.clone(), name3, &sec3);
 
     let mut builder = SignatureAggregator::try_new(order.clone(), &committee).unwrap();
     assert!(builder

--- a/fastpay_core/src/unit_tests/messages_tests.rs
+++ b/fastpay_core/src/unit_tests/messages_tests.rs
@@ -16,14 +16,13 @@ fn test_signed_values() {
     let committee = Committee::new(authorities);
 
     let transfer = Transfer {
-        sender: a1,
         recipient: Address::FastPay(a2),
         amount: Amount::from(1),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(transfer.clone(), &sec1);
-    let bad_order = TransferOrder::new(transfer, &sec2);
+    let order = TransferOrder::new(a1, transfer.clone(), &sec1);
+    let bad_order = TransferOrder::new(a1, transfer, &sec2);
 
     let v = SignedTransferOrder::new(order.clone(), a1, &sec1);
     assert!(v.check(&committee).is_ok());
@@ -50,14 +49,13 @@ fn test_certificates() {
     let committee = Committee::new(authorities);
 
     let transfer = Transfer {
-        sender: a1,
         recipient: Address::FastPay(a2),
         amount: Amount::from(1),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(transfer.clone(), &sec1);
-    let bad_order = TransferOrder::new(transfer, &sec2);
+    let order = TransferOrder::new(a1, transfer.clone(), &sec1);
+    let bad_order = TransferOrder::new(a1, transfer, &sec2);
 
     let v1 = SignedTransferOrder::new(order.clone(), a1, &sec1);
     let v2 = SignedTransferOrder::new(order.clone(), a2, &sec2);

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -22,12 +22,12 @@ fn test_error() {
 #[test]
 fn test_info_request() {
     let req1 = AccountInfoRequest {
-        sender: dbg_addr(0x20),
+        account_id: dbg_account(0x20),
         request_sequence_number: None,
         request_received_transfers_excluding_first_nth: None,
     };
     let req2 = AccountInfoRequest {
-        sender: dbg_addr(0x20),
+        account_id: dbg_account(0x20),
         request_sequence_number: Some(SequenceNumber::from(129)),
         request_received_transfers_excluding_first_nth: None,
     };
@@ -54,15 +54,16 @@ fn test_info_request() {
 
 #[test]
 fn test_order() {
-    let (sender_name, sender_key) = get_key_pair();
+    let (_, sender_key) = get_key_pair();
 
     let transfer = Transfer {
-        recipient: Address::Primary(dbg_addr(0x20)),
+        account_id: dbg_account(1),
+        recipient: Address::FastPay(dbg_account(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let transfer_order = TransferOrder::new(sender_name, transfer, &sender_key);
+    let transfer_order = TransferOrder::new(transfer, &sender_key);
 
     let buf = serialize_transfer_order(&transfer_order);
     let result = deserialize_message(buf.as_slice());
@@ -73,14 +74,15 @@ fn test_order() {
         panic!()
     }
 
-    let (sender_name, sender_key) = get_key_pair();
+    let (_, sender_key) = get_key_pair();
     let transfer2 = Transfer {
-        recipient: Address::FastPay(dbg_addr(0x20)),
+        account_id: dbg_account(1),
+        recipient: Address::FastPay(dbg_account(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let transfer_order2 = TransferOrder::new(sender_name, transfer2, &sender_key);
+    let transfer_order2 = TransferOrder::new(transfer2, &sender_key);
 
     let buf = serialize_transfer_order(&transfer_order2);
     let result = deserialize_message(buf.as_slice());
@@ -94,14 +96,15 @@ fn test_order() {
 
 #[test]
 fn test_vote() {
-    let (sender_name, sender_key) = get_key_pair();
+    let (_, sender_key) = get_key_pair();
     let transfer = Transfer {
+        account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(sender_name, transfer, &sender_key);
+    let order = TransferOrder::new(transfer, &sender_key);
 
     let (authority_name, authority_key) = get_key_pair();
     let vote = SignedTransferOrder::new(order, authority_name, &authority_key);
@@ -118,14 +121,15 @@ fn test_vote() {
 
 #[test]
 fn test_cert() {
-    let (sender_name, sender_key) = get_key_pair();
+    let (_, sender_key) = get_key_pair();
     let transfer = Transfer {
+        account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(sender_name, transfer, &sender_key);
+    let order = TransferOrder::new(transfer, &sender_key);
     let mut cert = CertifiedTransferOrder {
         value: order,
         signatures: Vec::new(),
@@ -150,14 +154,15 @@ fn test_cert() {
 
 #[test]
 fn test_info_response() {
-    let (sender_name, sender_key) = get_key_pair();
+    let (_, sender_key) = get_key_pair();
     let transfer = Transfer {
+        account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(sender_name, transfer, &sender_key);
+    let order = TransferOrder::new(transfer, &sender_key);
 
     let (auth_name, auth_key) = get_key_pair();
     let vote = SignedTransferOrder::new(order.clone(), auth_name, &auth_key);
@@ -175,7 +180,7 @@ fn test_info_response() {
     }
 
     let resp1 = AccountInfoResponse {
-        sender: dbg_addr(0x20),
+        account_id: dbg_account(0x20),
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
         pending_confirmation: None,
@@ -183,7 +188,7 @@ fn test_info_response() {
         requested_received_transfers: Vec::new(),
     };
     let resp2 = AccountInfoResponse {
-        sender: dbg_addr(0x20),
+        account_id: dbg_account(0x20),
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
         pending_confirmation: Some(vote.clone()),
@@ -191,7 +196,7 @@ fn test_info_response() {
         requested_received_transfers: Vec::new(),
     };
     let resp3 = AccountInfoResponse {
-        sender: dbg_addr(0x20),
+        account_id: dbg_account(0x20),
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
         pending_confirmation: None,
@@ -199,7 +204,7 @@ fn test_info_response() {
         requested_received_transfers: Vec::new(),
     };
     let resp4 = AccountInfoResponse {
-        sender: dbg_addr(0x20),
+        account_id: dbg_account(0x20),
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
         pending_confirmation: Some(vote),
@@ -221,8 +226,9 @@ fn test_info_response() {
 
 #[test]
 fn test_time_order() {
-    let (sender_name, sender_key) = get_key_pair();
+    let (_, sender_key) = get_key_pair();
     let transfer = Transfer {
+        account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
@@ -232,7 +238,7 @@ fn test_time_order() {
     let mut buf = Vec::new();
     let now = Instant::now();
     for _ in 0..100 {
-        let transfer_order = TransferOrder::new(sender_name, transfer.clone(), &sender_key);
+        let transfer_order = TransferOrder::new(transfer.clone(), &sender_key);
         serialize_transfer_order_into(&mut buf, &transfer_order).unwrap();
     }
     println!("Write Order: {} microsec", now.elapsed().as_micros() / 100);
@@ -253,14 +259,15 @@ fn test_time_order() {
 
 #[test]
 fn test_time_vote() {
-    let (sender_name, sender_key) = get_key_pair();
+    let (_, sender_key) = get_key_pair();
     let transfer = Transfer {
+        account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(sender_name, transfer, &sender_key);
+    let order = TransferOrder::new(transfer, &sender_key);
 
     let (authority_name, authority_key) = get_key_pair();
 
@@ -291,14 +298,15 @@ fn test_time_vote() {
 #[test]
 fn test_time_cert() {
     let count = 100;
-    let (sender_name, sender_key) = get_key_pair();
+    let (_, sender_key) = get_key_pair();
     let transfer = Transfer {
+        account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(sender_name, transfer, &sender_key);
+    let order = TransferOrder::new(transfer, &sender_key);
     let mut cert = CertifiedTransferOrder {
         value: order,
         signatures: Vec::new(),

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -54,7 +54,7 @@ fn test_info_request() {
 
 #[test]
 fn test_order() {
-    let (_, sender_key) = get_key_pair();
+    let sender_key = get_key_pair();
 
     let transfer = Transfer {
         account_id: dbg_account(1),
@@ -74,7 +74,7 @@ fn test_order() {
         panic!()
     }
 
-    let (_, sender_key) = get_key_pair();
+    let sender_key = get_key_pair();
     let transfer2 = Transfer {
         account_id: dbg_account(1),
         recipient: Address::FastPay(dbg_account(0x20)),
@@ -96,7 +96,7 @@ fn test_order() {
 
 #[test]
 fn test_vote() {
-    let (_, sender_key) = get_key_pair();
+    let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0x20)),
@@ -106,8 +106,8 @@ fn test_vote() {
     };
     let order = TransferOrder::new(transfer, &sender_key);
 
-    let (authority_name, authority_key) = get_key_pair();
-    let vote = SignedTransferOrder::new(order, authority_name, &authority_key);
+    let key = get_key_pair();
+    let vote = SignedTransferOrder::new(order, &key);
 
     let buf = serialize_vote(&vote);
     let result = deserialize_message(buf.as_slice());
@@ -121,7 +121,7 @@ fn test_vote() {
 
 #[test]
 fn test_cert() {
-    let (_, sender_key) = get_key_pair();
+    let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0x20)),
@@ -136,10 +136,10 @@ fn test_cert() {
     };
 
     for _ in 0..3 {
-        let (authority_name, authority_key) = get_key_pair();
-        let sig = Signature::new(&cert.value.transfer, &authority_key);
+        let key = get_key_pair();
+        let sig = Signature::new(&cert.value.transfer, &key);
 
-        cert.signatures.push((authority_name, sig));
+        cert.signatures.push((key.public(), sig));
     }
 
     let buf = serialize_cert(&cert);
@@ -154,7 +154,7 @@ fn test_cert() {
 
 #[test]
 fn test_info_response() {
-    let (_, sender_key) = get_key_pair();
+    let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0x20)),
@@ -164,8 +164,8 @@ fn test_info_response() {
     };
     let order = TransferOrder::new(transfer, &sender_key);
 
-    let (auth_name, auth_key) = get_key_pair();
-    let vote = SignedTransferOrder::new(order.clone(), auth_name, &auth_key);
+    let auth_key = get_key_pair();
+    let vote = SignedTransferOrder::new(order.clone(), &auth_key);
 
     let mut cert = CertifiedTransferOrder {
         value: order,
@@ -173,10 +173,10 @@ fn test_info_response() {
     };
 
     for _ in 0..3 {
-        let (authority_name, authority_key) = get_key_pair();
-        let sig = Signature::new(&cert.value.transfer, &authority_key);
+        let key = get_key_pair();
+        let sig = Signature::new(&cert.value.transfer, &key);
 
-        cert.signatures.push((authority_name, sig));
+        cert.signatures.push((key.public(), sig));
     }
 
     let resp1 = AccountInfoResponse {
@@ -226,7 +226,7 @@ fn test_info_response() {
 
 #[test]
 fn test_time_order() {
-    let (_, sender_key) = get_key_pair();
+    let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0x20)),
@@ -259,7 +259,7 @@ fn test_time_order() {
 
 #[test]
 fn test_time_vote() {
-    let (_, sender_key) = get_key_pair();
+    let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0x20)),
@@ -269,12 +269,12 @@ fn test_time_vote() {
     };
     let order = TransferOrder::new(transfer, &sender_key);
 
-    let (authority_name, authority_key) = get_key_pair();
+    let key = get_key_pair();
 
     let mut buf = Vec::new();
     let now = Instant::now();
     for _ in 0..100 {
-        let vote = SignedTransferOrder::new(order.clone(), authority_name, &authority_key);
+        let vote = SignedTransferOrder::new(order.clone(), &key);
         serialize_vote_into(&mut buf, &vote).unwrap();
     }
     println!("Write Vote: {} microsec", now.elapsed().as_micros() / 100);
@@ -298,7 +298,7 @@ fn test_time_vote() {
 #[test]
 fn test_time_cert() {
     let count = 100;
-    let (_, sender_key) = get_key_pair();
+    let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
         recipient: Address::Primary(dbg_addr(0)),
@@ -313,9 +313,9 @@ fn test_time_cert() {
     };
 
     for _ in 0..7 {
-        let (authority_name, authority_key) = get_key_pair();
-        let sig = Signature::new(&cert.value.transfer, &authority_key);
-        cert.signatures.push((authority_name, sig));
+        let key = get_key_pair();
+        let sig = Signature::new(&cert.value.transfer, &key);
+        cert.signatures.push((key.public(), sig));
     }
 
     let mut buf = Vec::new();

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -57,13 +57,12 @@ fn test_order() {
     let (sender_name, sender_key) = get_key_pair();
 
     let transfer = Transfer {
-        sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let transfer_order = TransferOrder::new(transfer, &sender_key);
+    let transfer_order = TransferOrder::new(sender_name, transfer, &sender_key);
 
     let buf = serialize_transfer_order(&transfer_order);
     let result = deserialize_message(buf.as_slice());
@@ -76,13 +75,12 @@ fn test_order() {
 
     let (sender_name, sender_key) = get_key_pair();
     let transfer2 = Transfer {
-        sender: sender_name,
         recipient: Address::FastPay(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let transfer_order2 = TransferOrder::new(transfer2, &sender_key);
+    let transfer_order2 = TransferOrder::new(sender_name, transfer2, &sender_key);
 
     let buf = serialize_transfer_order(&transfer_order2);
     let result = deserialize_message(buf.as_slice());
@@ -98,13 +96,12 @@ fn test_order() {
 fn test_vote() {
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(transfer, &sender_key);
+    let order = TransferOrder::new(sender_name, transfer, &sender_key);
 
     let (authority_name, authority_key) = get_key_pair();
     let vote = SignedTransferOrder::new(order, authority_name, &authority_key);
@@ -123,13 +120,12 @@ fn test_vote() {
 fn test_cert() {
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(transfer, &sender_key);
+    let order = TransferOrder::new(sender_name, transfer, &sender_key);
     let mut cert = CertifiedTransferOrder {
         value: order,
         signatures: Vec::new(),
@@ -156,13 +152,12 @@ fn test_cert() {
 fn test_info_response() {
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(transfer, &sender_key);
+    let order = TransferOrder::new(sender_name, transfer, &sender_key);
 
     let (auth_name, auth_key) = get_key_pair();
     let vote = SignedTransferOrder::new(order.clone(), auth_name, &auth_key);
@@ -228,7 +223,6 @@ fn test_info_response() {
 fn test_time_order() {
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
@@ -238,7 +232,7 @@ fn test_time_order() {
     let mut buf = Vec::new();
     let now = Instant::now();
     for _ in 0..100 {
-        let transfer_order = TransferOrder::new(transfer.clone(), &sender_key);
+        let transfer_order = TransferOrder::new(sender_name, transfer.clone(), &sender_key);
         serialize_transfer_order_into(&mut buf, &transfer_order).unwrap();
     }
     println!("Write Order: {} microsec", now.elapsed().as_micros() / 100);
@@ -261,13 +255,12 @@ fn test_time_order() {
 fn test_time_vote() {
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(transfer, &sender_key);
+    let order = TransferOrder::new(sender_name, transfer, &sender_key);
 
     let (authority_name, authority_key) = get_key_pair();
 
@@ -300,13 +293,12 @@ fn test_time_cert() {
     let count = 100;
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        sender: sender_name,
         recipient: Address::Primary(dbg_addr(0)),
         amount: Amount::from(5),
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(transfer, &sender_key);
+    let order = TransferOrder::new(sender_name, transfer, &sender_key);
     let mut cert = CertifiedTransferOrder {
         value: order,
         signatures: Vec::new(),

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -194,6 +194,7 @@ fn test_info_response() {
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
         pending_confirmation: None,
+        ongoing_confirmation: None,
         requested_certificate: None,
         requested_received_transfers: Vec::new(),
     };
@@ -202,6 +203,7 @@ fn test_info_response() {
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
         pending_confirmation: Some(vote.clone()),
+        ongoing_confirmation: None,
         requested_certificate: None,
         requested_received_transfers: Vec::new(),
     };
@@ -210,6 +212,7 @@ fn test_info_response() {
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
         pending_confirmation: None,
+        ongoing_confirmation: None,
         requested_certificate: Some(cert.clone()),
         requested_received_transfers: Vec::new(),
     };
@@ -218,6 +221,7 @@ fn test_info_response() {
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
         pending_confirmation: Some(vote),
+        ongoing_confirmation: None,
         requested_certificate: Some(cert),
         requested_received_transfers: Vec::new(),
     };

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -40,12 +40,12 @@ fn test_info_request() {
     assert!(result1.is_ok());
     assert!(result2.is_ok());
 
-    if let SerializedMessage::InfoReq(o) = result1.unwrap() {
+    if let SerializedMessage::InfoRequest(o) = result1.unwrap() {
         assert!(*o == req1);
     } else {
         panic!()
     }
-    if let SerializedMessage::InfoReq(o) = result2.unwrap() {
+    if let SerializedMessage::InfoRequest(o) = result2.unwrap() {
         assert!(*o == req2);
     } else {
         panic!()
@@ -153,7 +153,7 @@ fn test_cert() {
     let buf = serialize_cert(&cert);
     let result = deserialize_message(buf.as_slice());
     assert!(result.is_ok());
-    if let SerializedMessage::Cert(o) = result.unwrap() {
+    if let SerializedMessage::Confirmation(o) = result.unwrap() {
         assert!(*o == cert);
     } else {
         panic!()
@@ -226,7 +226,7 @@ fn test_info_response() {
         let buf = serialize_info_response(resp);
         let result = deserialize_message(buf.as_slice());
         assert!(result.is_ok());
-        if let SerializedMessage::InfoResp(o) = result.unwrap() {
+        if let SerializedMessage::InfoResponse(o) = result.unwrap() {
             assert!(*o == *resp);
         } else {
             panic!()
@@ -345,7 +345,7 @@ fn test_time_cert() {
     let now = Instant::now();
     let mut buf2 = buf.as_slice();
     for _ in 0..count {
-        if let SerializedMessage::Cert(cert) = deserialize_message(&mut buf2).unwrap() {
+        if let SerializedMessage::Confirmation(cert) = deserialize_message(&mut buf2).unwrap() {
             Signature::verify_batch(&cert.value.transfer, &cert.signatures).unwrap();
         }
     }

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -58,10 +58,12 @@ fn test_order() {
 
     let transfer = Transfer {
         account_id: dbg_account(1),
-        recipient: Address::FastPay(dbg_account(0x20)),
-        amount: Amount::from(5),
+        operation: Operation::Payment {
+            recipient: Address::FastPay(dbg_account(0x20)),
+            amount: Amount::from(5),
+            user_data: UserData::default(),
+        },
         sequence_number: SequenceNumber::new(),
-        user_data: UserData::default(),
     };
     let transfer_order = TransferOrder::new(transfer, &sender_key);
 
@@ -77,10 +79,12 @@ fn test_order() {
     let sender_key = get_key_pair();
     let transfer2 = Transfer {
         account_id: dbg_account(1),
-        recipient: Address::FastPay(dbg_account(0x20)),
-        amount: Amount::from(5),
+        operation: Operation::Payment {
+            recipient: Address::FastPay(dbg_account(0x20)),
+            amount: Amount::from(5),
+            user_data: UserData::default(),
+        },
         sequence_number: SequenceNumber::new(),
-        user_data: UserData::default(),
     };
     let transfer_order2 = TransferOrder::new(transfer2, &sender_key);
 
@@ -99,10 +103,12 @@ fn test_vote() {
     let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
-        recipient: Address::Primary(dbg_addr(0x20)),
-        amount: Amount::from(5),
+        operation: Operation::Payment {
+            recipient: Address::Primary(dbg_addr(0x20)),
+            amount: Amount::from(5),
+            user_data: UserData::default(),
+        },
         sequence_number: SequenceNumber::new(),
-        user_data: UserData::default(),
     };
     let order = TransferOrder::new(transfer, &sender_key);
 
@@ -124,10 +130,12 @@ fn test_cert() {
     let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
-        recipient: Address::Primary(dbg_addr(0x20)),
-        amount: Amount::from(5),
+        operation: Operation::Payment {
+            recipient: Address::Primary(dbg_addr(0x20)),
+            amount: Amount::from(5),
+            user_data: UserData::default(),
+        },
         sequence_number: SequenceNumber::new(),
-        user_data: UserData::default(),
     };
     let order = TransferOrder::new(transfer, &sender_key);
     let mut cert = CertifiedTransferOrder {
@@ -157,10 +165,12 @@ fn test_info_response() {
     let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
-        recipient: Address::Primary(dbg_addr(0x20)),
-        amount: Amount::from(5),
+        operation: Operation::Payment {
+            recipient: Address::Primary(dbg_addr(0x20)),
+            amount: Amount::from(5),
+            user_data: UserData::default(),
+        },
         sequence_number: SequenceNumber::new(),
-        user_data: UserData::default(),
     };
     let order = TransferOrder::new(transfer, &sender_key);
 
@@ -229,10 +239,12 @@ fn test_time_order() {
     let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
-        recipient: Address::Primary(dbg_addr(0x20)),
-        amount: Amount::from(5),
+        operation: Operation::Payment {
+            recipient: Address::Primary(dbg_addr(0x20)),
+            amount: Amount::from(5),
+            user_data: UserData::default(),
+        },
         sequence_number: SequenceNumber::new(),
-        user_data: UserData::default(),
     };
 
     let mut buf = Vec::new();
@@ -262,10 +274,12 @@ fn test_time_vote() {
     let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
-        recipient: Address::Primary(dbg_addr(0x20)),
-        amount: Amount::from(5),
+        operation: Operation::Payment {
+            recipient: Address::Primary(dbg_addr(0x20)),
+            amount: Amount::from(5),
+            user_data: UserData::default(),
+        },
         sequence_number: SequenceNumber::new(),
-        user_data: UserData::default(),
     };
     let order = TransferOrder::new(transfer, &sender_key);
 
@@ -301,10 +315,12 @@ fn test_time_cert() {
     let sender_key = get_key_pair();
     let transfer = Transfer {
         account_id: dbg_account(1),
-        recipient: Address::Primary(dbg_addr(0)),
-        amount: Amount::from(5),
+        operation: Operation::Payment {
+            recipient: Address::Primary(dbg_addr(0)),
+            amount: Amount::from(5),
+            user_data: UserData::default(),
+        },
         sequence_number: SequenceNumber::new(),
-        user_data: UserData::default(),
     };
     let order = TransferOrder::new(transfer, &sender_key);
     let mut cert = CertifiedTransferOrder {

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -1,8 +1,12 @@
 ---
+AccountId:
+  NEWTYPESTRUCT:
+    SEQ:
+      TYPENAME: SequenceNumber
 AccountInfoRequest:
   STRUCT:
-    - sender:
-        TYPENAME: PublicKeyBytes
+    - account_id:
+        TYPENAME: AccountId
     - request_sequence_number:
         OPTION:
           TYPENAME: SequenceNumber
@@ -10,8 +14,8 @@ AccountInfoRequest:
         OPTION: U64
 AccountInfoResponse:
   STRUCT:
-    - sender:
-        TYPENAME: PublicKeyBytes
+    - account_id:
+        TYPENAME: AccountId
     - balance:
         TYPENAME: Balance
     - next_sequence_number:
@@ -34,7 +38,7 @@ Address:
     1:
       FastPay:
         NEWTYPE:
-          TYPENAME: PublicKeyBytes
+          TYPENAME: AccountId
 Amount:
   NEWTYPESTRUCT: U64
 Balance:
@@ -51,67 +55,75 @@ CertifiedTransferOrder:
 FastPayError:
   ENUM:
     0:
+      InvalidOwner: UNIT
+    1:
       InvalidSignature:
         STRUCT:
           - error: STR
-    1:
-      UnknownSigner: UNIT
     2:
-      CertificateRequiresQuorum: UNIT
+      UnknownSigner: UNIT
     3:
-      IncorrectTransferAmount: UNIT
+      CertificateRequiresQuorum: UNIT
     4:
-      UnexpectedSequenceNumber: UNIT
+      IncorrectTransferAmount: UNIT
     5:
+      UnexpectedSequenceNumber: UNIT
+    6:
       InsufficientFunding:
         STRUCT:
           - current_balance:
               TYPENAME: Balance
-    6:
+    7:
       PreviousTransferMustBeConfirmedFirst:
         STRUCT:
           - pending_confirmation:
               TYPENAME: TransferOrder
-    7:
-      ErrorWhileProcessingTransferOrder: UNIT
     8:
-      ErrorWhileRequestingCertificate: UNIT
+      ErrorWhileProcessingTransferOrder: UNIT
     9:
-      MissingEalierConfirmations:
+      ErrorWhileRequestingCertificate: UNIT
+    10:
+      MissingEarlierConfirmations:
         STRUCT:
           - current_sequence_number:
               TYPENAME: SequenceNumber
-    10:
-      UnexpectedTransactionIndex: UNIT
     11:
-      CertificateNotfound: UNIT
+      UnexpectedTransactionIndex: UNIT
     12:
-      UnknownSenderAccount: UNIT
+      CertificateNotfound: UNIT
     13:
-      CertificateAuthorityReuse: UNIT
+      UnknownSenderAccount:
+        NEWTYPE:
+          TYPENAME: AccountId
     14:
-      InvalidSequenceNumber: UNIT
+      UnknownRecipientAccount:
+        NEWTYPE:
+          TYPENAME: AccountId
     15:
-      SequenceOverflow: UNIT
+      CertificateAuthorityReuse: UNIT
     16:
-      SequenceUnderflow: UNIT
+      InvalidSequenceNumber: UNIT
     17:
-      AmountOverflow: UNIT
+      SequenceOverflow: UNIT
     18:
-      AmountUnderflow: UNIT
+      SequenceUnderflow: UNIT
     19:
-      BalanceOverflow: UNIT
+      AmountOverflow: UNIT
     20:
-      BalanceUnderflow: UNIT
+      AmountUnderflow: UNIT
     21:
-      WrongShard: UNIT
+      BalanceOverflow: UNIT
     22:
-      InvalidCrossShardUpdate: UNIT
+      BalanceUnderflow: UNIT
     23:
-      InvalidDecoding: UNIT
+      WrongShard: UNIT
     24:
-      UnexpectedMessage: UNIT
+      InvalidCrossShardUpdate: UNIT
     25:
+      InvalidDecoding: UNIT
+    26:
+      UnexpectedMessage: UNIT
+    27:
       ClientIoError:
         STRUCT:
           - error: STR
@@ -167,6 +179,8 @@ SignedTransferOrder:
         TYPENAME: Signature
 Transfer:
   STRUCT:
+    - account_id:
+        TYPENAME: AccountId
     - recipient:
         TYPENAME: Address
     - amount:
@@ -179,7 +193,7 @@ TransferOrder:
   STRUCT:
     - transfer:
         TYPENAME: Transfer
-    - sender:
+    - owner:
         TYPENAME: PublicKeyBytes
     - signature:
         TYPENAME: Signature

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -74,56 +74,60 @@ FastPayError:
           - current_balance:
               TYPENAME: Balance
     7:
+      InvalidNewAccountId:
+        NEWTYPE:
+          TYPENAME: AccountId
+    8:
       PreviousTransferMustBeConfirmedFirst:
         STRUCT:
           - pending_confirmation:
               TYPENAME: TransferOrder
-    8:
-      ErrorWhileProcessingTransferOrder: UNIT
     9:
-      ErrorWhileRequestingCertificate: UNIT
+      ErrorWhileProcessingTransferOrder: UNIT
     10:
+      ErrorWhileRequestingCertificate: UNIT
+    11:
       MissingEarlierConfirmations:
         STRUCT:
           - current_sequence_number:
               TYPENAME: SequenceNumber
-    11:
-      UnexpectedTransactionIndex: UNIT
     12:
-      CertificateNotfound: UNIT
+      UnexpectedTransactionIndex: UNIT
     13:
+      CertificateNotfound: UNIT
+    14:
       UnknownSenderAccount:
         NEWTYPE:
           TYPENAME: AccountId
-    14:
+    15:
       UnknownRecipientAccount:
         NEWTYPE:
           TYPENAME: AccountId
-    15:
-      CertificateAuthorityReuse: UNIT
     16:
-      InvalidSequenceNumber: UNIT
+      CertificateAuthorityReuse: UNIT
     17:
-      SequenceOverflow: UNIT
+      InvalidSequenceNumber: UNIT
     18:
-      SequenceUnderflow: UNIT
+      SequenceOverflow: UNIT
     19:
-      AmountOverflow: UNIT
+      SequenceUnderflow: UNIT
     20:
-      AmountUnderflow: UNIT
+      AmountOverflow: UNIT
     21:
-      BalanceOverflow: UNIT
+      AmountUnderflow: UNIT
     22:
-      BalanceUnderflow: UNIT
+      BalanceOverflow: UNIT
     23:
-      WrongShard: UNIT
+      BalanceUnderflow: UNIT
     24:
-      InvalidCrossShardUpdate: UNIT
+      WrongShard: UNIT
     25:
-      InvalidDecoding: UNIT
+      InvalidCrossShardUpdate: UNIT
     26:
-      UnexpectedMessage: UNIT
+      InvalidDecoding: UNIT
     27:
+      UnexpectedMessage: UNIT
+    28:
       ClientIoError:
         STRUCT:
           - error: STR
@@ -138,6 +142,18 @@ Operation:
               TYPENAME: Amount
           - user_data:
               TYPENAME: UserData
+    1:
+      CreateAccount:
+        STRUCT:
+          - new_id:
+              TYPENAME: AccountId
+          - new_owner:
+              TYPENAME: PublicKeyBytes
+    2:
+      ChangeOwner:
+        STRUCT:
+          - new_owner:
+              TYPENAME: PublicKeyBytes
 PublicKeyBytes:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -167,8 +167,6 @@ SignedTransferOrder:
         TYPENAME: Signature
 Transfer:
   STRUCT:
-    - sender:
-        TYPENAME: PublicKeyBytes
     - recipient:
         TYPENAME: Address
     - amount:
@@ -181,6 +179,8 @@ TransferOrder:
   STRUCT:
     - transfer:
         TYPENAME: Transfer
+    - sender:
+        TYPENAME: PublicKeyBytes
     - signature:
         TYPENAME: Signature
 UserData:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -127,6 +127,17 @@ FastPayError:
       ClientIoError:
         STRUCT:
           - error: STR
+Operation:
+  ENUM:
+    0:
+      Payment:
+        STRUCT:
+          - recipient:
+              TYPENAME: Address
+          - amount:
+              TYPENAME: Amount
+          - user_data:
+              TYPENAME: UserData
 PublicKeyBytes:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -181,14 +192,10 @@ Transfer:
   STRUCT:
     - account_id:
         TYPENAME: AccountId
-    - recipient:
-        TYPENAME: Address
-    - amount:
-        TYPENAME: Amount
+    - operation:
+        TYPENAME: Operation
     - sequence_number:
         TYPENAME: SequenceNumber
-    - user_data:
-        TYPENAME: UserData
 TransferOrder:
   STRUCT:
     - transfer:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -52,6 +52,37 @@ CertifiedTransferOrder:
           TUPLE:
             - TYPENAME: PublicKeyBytes
             - TYPENAME: Signature
+ConfirmationOutcome:
+  ENUM:
+    0:
+      Complete: UNIT
+    1:
+      Retry: UNIT
+    2:
+      Cancel: UNIT
+CrossShardRequest:
+  ENUM:
+    0:
+      UpdateRecipientAccount:
+        STRUCT:
+          - certificate:
+              TYPENAME: CertifiedTransferOrder
+    1:
+      VerifyAccountDeletion:
+        STRUCT:
+          - parent_id:
+              TYPENAME: AccountId
+          - sequence_number:
+              TYPENAME: SequenceNumber
+          - certificate:
+              TYPENAME: CertifiedTransferOrder
+    2:
+      UpdateSenderAccount:
+        STRUCT:
+          - certificate:
+              TYPENAME: CertifiedTransferOrder
+          - outcome:
+              TYPENAME: ConfirmationOutcome
 FastPayError:
   ENUM:
     0:
@@ -122,7 +153,7 @@ FastPayError:
     24:
       WrongShard: UNIT
     25:
-      InvalidCrossShardUpdate: UNIT
+      InvalidCrossShardRequest: UNIT
     26:
       InvalidDecoding: UNIT
     27:
@@ -172,25 +203,25 @@ SerializedMessage:
         NEWTYPE:
           TYPENAME: SignedTransferOrder
     2:
-      Cert:
+      Confirmation:
         NEWTYPE:
           TYPENAME: CertifiedTransferOrder
     3:
-      CrossShard:
-        NEWTYPE:
-          TYPENAME: CertifiedTransferOrder
-    4:
       Error:
         NEWTYPE:
           TYPENAME: FastPayError
-    5:
-      InfoReq:
+    4:
+      InfoRequest:
         NEWTYPE:
           TYPENAME: AccountInfoRequest
-    6:
-      InfoResp:
+    5:
+      InfoResponse:
         NEWTYPE:
           TYPENAME: AccountInfoResponse
+    6:
+      CrossShardRequest:
+        NEWTYPE:
+          TYPENAME: CrossShardRequest
 Signature:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -23,6 +23,9 @@ AccountInfoResponse:
     - pending_confirmation:
         OPTION:
           TYPENAME: SignedTransferOrder
+    - ongoing_confirmation:
+        OPTION:
+          TYPENAME: CertifiedTransferOrder
     - requested_certificate:
         OPTION:
           TYPENAME: CertifiedTransferOrder


### PR DESCRIPTION
* Start a new branch of FastPay called "extensions" meant to experiment with new features
* The main difference so far is the replacement of FastPay addresses by unique "account ids". This enables key rotation, account deletion, etc (hopefully more coming soon) at the expense of an increased complexity in shard requests.
* The client SDK is not using the new operations yet.