### PR TITLE
[fastpay] remove confusing option --initial-balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ FastPay allows a set of distributed authorities, some of which are Byzantine, to
 ```bash
 cargo build --release
 cd target/release
-rm -f *.json
+rm -f *.json *.txt
 
 # Create configuration files for 4 authorities with 4 shards each.
 # * Private server states are stored in `server*.json`.
@@ -26,21 +26,21 @@ done
 
 # Create configuration files for 1000 user accounts.
 # * Private account states are stored in one local wallet `accounts.json`.
-# * `initial_accounts.json` is used to mint initial balances on the server side.
-./client --committee committee.json --accounts accounts.json create_accounts 1000 --initial-funding 100 >> initial_accounts.json
+# * `initial_accounts.txt` is used to mint the corresponding initial balances at startup on the server side.
+./client --committee committee.json --accounts accounts.json create_accounts 1000 --initial-funding 100 >> initial_accounts.txt
 
 # Start servers
 for I in 1 2 3 4
 do
     for J in $(seq 0 3)
     do
-        ./server --server server"$I".json run --shard "$J" --initial-accounts initial_accounts.json --initial-balance 100 --committee committee.json &
+        ./server --server server"$I".json run --shard "$J" --initial-accounts initial_accounts.txt --committee committee.json &
     done
  done
 
 # Query (locally cached) balance for first and last user account
-ACCOUNT1="`head -n 1 initial_accounts.json`"
-ACCOUNT2="`tail -n -1 initial_accounts.json`"
+ACCOUNT1="`head -n 1 initial_accounts.txt | awk -F: '{ print $1 }'`"
+ACCOUNT2="`tail -n -1 initial_accounts.txt | awk -F: '{ print $1 }'`"
 ./client --committee committee.json --accounts accounts.json query_balance "$ACCOUNT1"
 ./client --committee committee.json --accounts accounts.json query_balance "$ACCOUNT2"
 

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -531,7 +531,7 @@ fn main() {
             let num_accounts: u32 = num;
             for _ in 0..num_accounts {
                 let account = UserAccount::new(initial_funding);
-                println!("{}", encode_address(&account.address));
+                println!("{}:{}", encode_address(&account.address), initial_funding);
                 accounts_config.insert(account);
             }
             accounts_config

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -17,7 +17,6 @@ fn make_shard_server(
     server_config_path: &str,
     committee_config_path: &str,
     initial_accounts_config_path: &str,
-    initial_balance: Balance,
     buffer_size: usize,
     cross_shard_queue_size: usize,
     shard: u32,
@@ -41,12 +40,12 @@ fn make_shard_server(
     );
 
     // Load initial states
-    for address in &initial_accounts_config.addresses {
+    for (address, balance) in &initial_accounts_config.accounts {
         if AuthorityState::get_shard(num_shards, address) != shard {
             continue;
         }
         let client = AccountOffchainState {
-            balance: initial_balance,
+            balance: *balance,
             next_sequence_number: SequenceNumber::from(0),
             pending_confirmation: None,
             confirmed_log: Vec::new(),
@@ -71,7 +70,6 @@ fn make_servers(
     server_config_path: &str,
     committee_config_path: &str,
     initial_accounts_config_path: &str,
-    initial_balance: Balance,
     buffer_size: usize,
     cross_shard_queue_size: usize,
 ) -> Vec<network::Server> {
@@ -86,7 +84,6 @@ fn make_servers(
             server_config_path,
             committee_config_path,
             initial_accounts_config_path,
-            initial_balance,
             buffer_size,
             cross_shard_queue_size,
             shard,
@@ -131,10 +128,6 @@ enum ServerCommands {
         #[structopt(long)]
         initial_accounts: String,
 
-        /// Path to the file describing the initial balance of user accounts
-        #[structopt(long)]
-        initial_balance: Balance,
-
         /// Runs a specific shard (from 0 to shards-1)
         #[structopt(long)]
         shard: Option<u32>,
@@ -173,7 +166,6 @@ fn main() {
             cross_shard_queue_size,
             committee,
             initial_accounts,
-            initial_balance,
             shard,
         } => {
             // Run the server
@@ -185,7 +177,6 @@ fn main() {
                         server_config_path,
                         &committee,
                         &initial_accounts,
-                        initial_balance,
                         buffer_size,
                         cross_shard_queue_size,
                         shard,
@@ -199,7 +190,6 @@ fn main() {
                         server_config_path,
                         &committee,
                         &initial_accounts,
-                        initial_balance,
                         buffer_size,
                         cross_shard_queue_size,
                     )

--- a/fastpay_core/src/base_types.rs
+++ b/fastpay_core/src/base_types.rs
@@ -181,6 +181,12 @@ impl Balance {
     }
 }
 
+impl std::fmt::Display for Balance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl std::str::FromStr for Balance {
     type Err = std::num::ParseIntError;
 


### PR DESCRIPTION
To initialize server-side accounts states at startup, the `server` binary was reading public keys from `initial_accounts.json` and balances from `--initial-balance N`. This was confusing because the initial balances were already given once (with `client create_accounts --initial-funding M`) when creating the file `initial_accounts.json` (which was not also quite a JSON file).

This PR fixes the issue by adding a column to write initial balances into `initial_accounts.txt`. See also the updated README file.

Test plan: `cargo test -- --ignored`