### PR TITLE
Improve output for format test

### DIFF
--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -17,12 +17,15 @@ tokio = { version = "0.2.22", features = ["full"] }
 ed25519 = { version = "1.0.1"}
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 serde_json = "1.0.57"
-serde-reflection = "0.3.2"
 serde-name = "0.1.2"
-serde_yaml = "0.8.17"
 structopt = "0.3.21"
 
-[[bin]]
+[dev-dependencies]
+similar-asserts = { version = "1.1.0" }
+serde-reflection = "0.3.2"
+serde_yaml = "0.8.17"
+
+[[example]]
 name = "generate-format"
 path = "src/generate_format.rs"
 test = false

--- a/fastpay_core/src/generate_format.rs
+++ b/fastpay_core/src/generate_format.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastpay_core::{error, messages, serialize};
-
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
 use std::{fs::File, io::Write};
 use structopt::{clap::arg_enum, StructOpt};
@@ -58,9 +57,9 @@ fn main() {
             writeln!(f, "{}", content).unwrap();
         }
         Action::Test => {
-            let f = File::open(FILE_PATH).unwrap();
-            let reference: serde_reflection::Registry = serde_yaml::from_reader(f).unwrap();
-            assert_eq!(registry, reference);
+            let reference = std::fs::read_to_string(FILE_PATH).unwrap();
+            let content = serde_yaml::to_string(&registry).unwrap() + "\n";
+            similar_asserts::assert_str_eq!(&reference, &content);
         }
     }
 }

--- a/fastpay_core/tests/format.rs
+++ b/fastpay_core/tests/format.rs
@@ -3,8 +3,9 @@
 
 #[test]
 fn test_format() {
-    let status = std::process::Command::new("target/debug/generate-format")
+    let status = std::process::Command::new("cargo")
         .current_dir("..")
+        .args(&["run", "--example", "generate-format", "--"])
         .arg("test")
         .status()
         .expect("failed to execute process");


### PR DESCRIPTION
* Make generate-format as an "example" instead of a "bin" so that it uses cargo "dev-dependencies"
* Use a prettier `assert` macro based on the "similar" crate