### PR TITLE
Make operations more extensible and add external transparent coins

### DIFF
--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -142,7 +142,7 @@ impl ClientServerBenchmark {
             };
             states[shard].accounts.insert(id.clone(), client);
 
-            let transfer = Transfer {
+            let request = Request {
                 account_id: id.clone(),
                 operation: Operation::Payment {
                     recipient: Address::FastPay(next_recipient),
@@ -151,21 +151,21 @@ impl ClientServerBenchmark {
                 },
                 sequence_number: SequenceNumber::from(0),
             };
-            let order = TransferOrder::new(transfer.clone(), &key_pair);
+            let order = RequestOrder::new(request.clone(), &key_pair);
             let shard = AuthorityState::get_shard(self.num_shards, &id);
 
             // Serialize order
-            let bufx = serialize_transfer_order(&order);
+            let bufx = serialize_request_order(&order);
             assert!(!bufx.is_empty());
 
             // Make certificate
-            let mut certificate = CertifiedTransferOrder {
+            let mut certificate = CertifiedRequestOrder {
                 value: order,
                 signatures: Vec::new(),
             };
             for i in 0..committee.quorum_threshold() {
                 let key = keys.get(i).unwrap();
-                let sig = Signature::new(&certificate.value.transfer, key);
+                let sig = Signature::new(&certificate.value.request, key);
                 certificate.signatures.push((key.public(), sig));
             }
 

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -144,7 +144,7 @@ impl ClientServerBenchmark {
 
             let request = Request {
                 account_id: id.clone(),
-                operation: Operation::Payment {
+                operation: Operation::Transfer {
                     recipient: Address::FastPay(next_recipient),
                     amount: Amount::from(50),
                     user_data: UserData::default(),

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -135,7 +135,7 @@ impl ClientServerBenchmark {
                 owner: Some(owner),
                 balance: Balance::from(Amount::from(100)),
                 next_sequence_number: SequenceNumber::from(0),
-                pending_confirmation: None,
+                pending: None,
                 confirmed_log: Vec::new(),
                 synchronization_log: Vec::new(),
                 received_log: Vec::new(),

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -159,8 +159,9 @@ impl ClientServerBenchmark {
             assert!(!bufx.is_empty());
 
             // Make certificate
-            let mut certificate = CertifiedRequest {
-                value: request,
+            let value = Value::Confirm(request);
+            let mut certificate = Certificate {
+                value,
                 signatures: Vec::new(),
             };
             for i in 0..committee.quorum_threshold() {

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -159,13 +159,13 @@ impl ClientServerBenchmark {
             assert!(!bufx.is_empty());
 
             // Make certificate
-            let mut certificate = CertifiedRequestOrder {
-                value: order,
+            let mut certificate = CertifiedRequest {
+                value: request,
                 signatures: Vec::new(),
             };
             for i in 0..committee.quorum_threshold() {
                 let key = keys.get(i).unwrap();
-                let sig = Signature::new(&certificate.value.request, key);
+                let sig = Signature::new(&certificate.value, key);
                 certificate.signatures.push((key.public(), sig));
             }
 

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -151,7 +151,7 @@ impl ClientServerBenchmark {
                 },
                 sequence_number: SequenceNumber::from(0),
             };
-            let order = RequestOrder::new(request.clone(), &key_pair);
+            let order = RequestOrder::new(request.clone(), &key_pair, Vec::new());
             let shard = AuthorityState::get_shard(self.num_shards, &id);
 
             // Serialize order

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -476,9 +476,7 @@ fn main() {
                 .await;
                 let votes: Vec<_> = responses
                     .into_iter()
-                    .filter_map(|buf| {
-                        deserialize_response(&buf[..]).and_then(|info| info.pending_confirmation)
-                    })
+                    .filter_map(|buf| deserialize_response(&buf[..]).and_then(|info| info.pending))
                     .collect();
                 warn!("Received {} valid votes.", votes.len());
 

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -99,7 +99,7 @@ fn make_benchmark_request_orders(
     for account in accounts_config.accounts_mut() {
         let request = Request {
             account_id: account.account_id.clone(),
-            operation: Operation::Payment {
+            operation: Operation::Transfer {
                 recipient: Address::FastPay(next_recipient),
                 amount: Amount::from(1),
                 user_data: UserData::default(),
@@ -279,7 +279,7 @@ fn deserialize_response(response: &[u8]) -> Option<AccountInfoResponse> {
 #[derive(StructOpt)]
 #[structopt(
     name = "FastPay Client",
-    about = "A Byzantine fault tolerant payments sidechain with low-latency finality and high throughput"
+    about = "A Byzantine-fault tolerant sidechain with low-latency finality and high throughput"
 )]
 struct ClientOpt {
     /// Sets the file storing the state of our user accounts (an empty one will be created if missing)

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -108,7 +108,7 @@ fn make_benchmark_request_orders(
         };
         debug!("Preparing request order: {:?}", request);
         account.next_sequence_number = account.next_sequence_number.increment().unwrap();
-        let order = RequestOrder::new(request.clone(), &account.key_pair);
+        let order = RequestOrder::new(request.clone(), &account.key_pair, Vec::new());
         orders.push(order.clone());
         let serialized_order = serialize_request_order(&order);
         serialized_orders.push((account.account_id.clone(), serialized_order.into()));

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -5,7 +5,7 @@ use crate::transport::NetworkProtocol;
 use fastpay_core::{
     base_types::*,
     client::ClientState,
-    messages::{Address, CertifiedTransferOrder, Operation},
+    messages::{Address, CertifiedRequestOrder, Operation},
 };
 
 use serde::{Deserialize, Serialize};
@@ -92,8 +92,8 @@ pub struct UserAccount {
     pub key_pair: KeyPair,
     pub next_sequence_number: SequenceNumber,
     pub balance: Balance,
-    pub sent_certificates: Vec<CertifiedTransferOrder>,
-    pub received_certificates: Vec<CertifiedTransferOrder>,
+    pub sent_certificates: Vec<CertifiedRequestOrder>,
+    pub received_certificates: Vec<CertifiedRequestOrder>,
 }
 
 impl UserAccount {
@@ -146,13 +146,13 @@ impl AccountsConfig {
         account.received_certificates = state.received_certificates().cloned().collect();
     }
 
-    pub fn update_for_received_transfer(&mut self, certificate: CertifiedTransferOrder) {
-        let transfer = &certificate.value.transfer;
+    pub fn update_for_received_request(&mut self, certificate: CertifiedRequestOrder) {
+        let request = &certificate.value.request;
         if let Operation::Payment {
             recipient: Address::FastPay(recipient),
             amount,
             ..
-        } = &transfer.operation
+        } = &request.operation
         {
             if let Some(config) = self.accounts.get_mut(recipient) {
                 if let Err(position) = config

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -5,7 +5,7 @@ use crate::transport::NetworkProtocol;
 use fastpay_core::{
     base_types::*,
     client::ClientState,
-    messages::{Address, CertifiedRequestOrder, Operation},
+    messages::{Address, CertifiedRequest, Operation},
 };
 
 use serde::{Deserialize, Serialize};
@@ -92,8 +92,8 @@ pub struct UserAccount {
     pub key_pair: KeyPair,
     pub next_sequence_number: SequenceNumber,
     pub balance: Balance,
-    pub sent_certificates: Vec<CertifiedRequestOrder>,
-    pub received_certificates: Vec<CertifiedRequestOrder>,
+    pub sent_certificates: Vec<CertifiedRequest>,
+    pub received_certificates: Vec<CertifiedRequest>,
 }
 
 impl UserAccount {
@@ -146,8 +146,8 @@ impl AccountsConfig {
         account.received_certificates = state.received_certificates().cloned().collect();
     }
 
-    pub fn update_for_received_request(&mut self, certificate: CertifiedRequestOrder) {
-        let request = &certificate.value.request;
+    pub fn update_for_received_request(&mut self, certificate: CertifiedRequest) {
+        let request = &certificate.value;
         if let Operation::Payment {
             recipient: Address::FastPay(recipient),
             amount,

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -149,7 +149,7 @@ impl AccountsConfig {
     pub fn update_for_received_request(&mut self, certificate: Certificate) {
         let request = match &certificate.value {
             Value::Confirm(r) => r,
-            Value::Lock(_) => return,
+            Value::Coin(_) | Value::Lock(_) => return,
         };
         if let Operation::Transfer {
             recipient: Address::FastPay(recipient),

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -148,7 +148,7 @@ impl AccountsConfig {
 
     pub fn update_for_received_request(&mut self, certificate: CertifiedRequest) {
         let request = &certificate.value;
-        if let Operation::Payment {
+        if let Operation::Transfer {
             recipient: Address::FastPay(recipient),
             amount,
             ..

--- a/fastpay/src/network.rs
+++ b/fastpay/src/network.rs
@@ -321,7 +321,7 @@ impl AuthorityClient for Client {
         Box::pin(async move {
             let shard = AuthorityState::get_shard(
                 self.num_shards,
-                &order.request_certificate.value.request.account_id,
+                &order.request_certificate.value.account_id,
             );
             self.send_recv_bytes(shard, serialize_cert(&order.request_certificate))
                 .await

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -43,7 +43,7 @@ fn make_shard_server(
             owner: Some(*owner),
             balance: *balance,
             next_sequence_number: SequenceNumber::from(0),
-            pending_confirmation: None,
+            pending: None,
             confirmed_log: Vec::new(),
             synchronization_log: Vec::new(),
             received_log: Vec::new(),

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -10,6 +10,7 @@ bcs = "0.1.3"
 bincode = "1.3.1"
 failure = "0.1.8"
 futures = "0.3.5"
+generic-array = { version = "0.14.4", features = ["serde"] }
 hex = "0.4.3"
 rand = "0.7.3"
 serde = { version = "1.0.115", features = ["derive"] }
@@ -18,6 +19,7 @@ ed25519 = { version = "1.0.1"}
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 serde_json = "1.0.57"
 serde-name = "0.1.2"
+sha2 = "0.9.8"
 structopt = "0.3.21"
 
 [dev-dependencies]

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -141,7 +141,7 @@ impl Authority for AuthorityState {
                             }
                         );
                     }
-                    Operation::CreateAccount { new_id, .. } => {
+                    Operation::OpenAccount { new_id, .. } => {
                         let expected_id = account_id.make_child(transfer.sequence_number);
                         fp_ensure!(
                             new_id == &expected_id,
@@ -198,7 +198,7 @@ impl Authority for AuthorityState {
 
         // Execute the sender's side of the operation.
         let info = match &transfer.operation {
-            Operation::CreateAccount { .. } => sender_account.make_account_info(sender.clone()),
+            Operation::OpenAccount { .. } => sender_account.make_account_info(sender.clone()),
             Operation::ChangeOwner { new_owner } => {
                 sender_account.owner = Some(*new_owner);
                 sender_account.make_account_info(sender.clone())
@@ -253,7 +253,7 @@ impl Authority for AuthorityState {
                     .unwrap_or_else(|_| Balance::max());
                 account.received_log.push(certificate.clone());
             }
-            Operation::CreateAccount { new_id, new_owner } => {
+            Operation::OpenAccount { new_id, new_owner } => {
                 fp_ensure!(self.in_shard(new_id), FastPayError::WrongShard);
                 let account = self.accounts.entry(new_id.clone()).or_default();
                 assert!(account.owner.is_none()); // guaranteed under BFT assumptions.

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -129,7 +129,7 @@ impl Authority for AuthorityState {
                     FastPayError::UnexpectedSequenceNumber
                 );
                 match &request.operation {
-                    Operation::Payment { amount, .. } => {
+                    Operation::Transfer { amount, .. } => {
                         fp_ensure!(
                             *amount > Amount::zero(),
                             FastPayError::IncorrectTransferAmount
@@ -209,7 +209,7 @@ impl Authority for AuthorityState {
                 info.owner = None; // Signal that the account was deleted.
                 info
             }
-            Operation::Payment { amount, .. } => {
+            Operation::Transfer { amount, .. } => {
                 sender_account.balance = sender_account.balance.try_sub((*amount).into())?;
                 sender_account.make_account_info(sender.clone())
             }
@@ -240,7 +240,7 @@ impl Authority for AuthorityState {
         let request = &certificate.value;
         // Execute the recipient's side of the operation.
         match &request.operation {
-            Operation::Payment {
+            Operation::Transfer {
                 recipient: Address::FastPay(recipient),
                 amount,
                 ..
@@ -261,7 +261,7 @@ impl Authority for AuthorityState {
                 account.received_log.push(certificate.clone());
             }
             Operation::CloseAccount
-            | Operation::Payment {
+            | Operation::Transfer {
                 recipient: Address::Primary(_),
                 ..
             }

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -104,11 +104,7 @@ impl Authority for AuthorityState {
         match self.accounts.get_mut(&account_id) {
             None => fp_bail!(FastPayError::UnknownSenderAccount(account_id)),
             Some(account) => {
-                fp_ensure!(
-                    account.owner == Some(order.owner),
-                    FastPayError::InvalidOwner
-                );
-                order.check_signature()?;
+                order.check(&account.owner)?;
                 let request = order.request;
                 fp_ensure!(
                     request.sequence_number <= SequenceNumber::max(),

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -22,10 +22,10 @@ pub struct AccountState {
     pub pending: Option<Vote>,
     /// All confirmed certificates for this sender.
     pub confirmed_log: Vec<Certificate>,
-    /// All executed Primary synchronization orders for this recipient.
-    pub synchronization_log: Vec<PrimarySynchronizationOrder>,
     /// All confirmed certificates as a receiver.
     pub received_log: Vec<Certificate>,
+    /// All executed Primary synchronization orders for this recipient.
+    pub synchronization_log: Vec<PrimarySynchronizationOrder>,
 }
 
 pub struct AuthorityState {

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -114,6 +114,7 @@ impl AuthorityState {
             | Operation::SpendAndTransfer {
                 recipient: Address::FastPay(recipient),
                 amount,
+                ..
             } => {
                 fp_ensure!(self.in_shard(recipient), FastPayError::WrongShard);
                 let account = self.accounts.entry(recipient.clone()).or_default();
@@ -291,7 +292,7 @@ impl Authority for AuthorityState {
                     // Verify locked account.
                     fp_ensure!(
                         account_id == &source.account_id
-                            && account_balance == &source.amount
+                            && account_balance == &source.account_balance
                             && contract_hash == &hash,
                         FastPayError::InvalidCoinCreationOrder
                     );

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -9,7 +9,8 @@ use std::collections::BTreeMap;
 mod authority_tests;
 
 /// State of an (offchain) FastPay account.
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Debug)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct AccountState {
     /// Owner of the account. An account without owner cannot execute operations.
     pub owner: Option<AccountOwner>,

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -535,7 +535,7 @@ where
                 Operation::Payment { amount, .. } => {
                     new_balance = new_balance.try_sub((*amount).into())?;
                 }
-                Operation::CreateAccount { .. }
+                Operation::OpenAccount { .. }
                 | Operation::CloseAccount
                 | Operation::ChangeOwner { .. } => (),
             }
@@ -566,7 +566,7 @@ where
                 Operation::Payment { amount, .. } => {
                     new_balance = new_balance.try_add((*amount).into())?;
                 }
-                Operation::CreateAccount { .. }
+                Operation::OpenAccount { .. }
                 | Operation::CloseAccount
                 | Operation::ChangeOwner { .. } => (),
             }
@@ -682,7 +682,7 @@ where
                         "Transfer should be received by us."
                     );
                 }
-                Operation::CreateAccount { .. }
+                Operation::OpenAccount { .. }
                 | Operation::CloseAccount
                 | Operation::ChangeOwner { .. } => {
                     // TODO: decide what to do
@@ -703,7 +703,7 @@ where
                     Operation::Payment { amount, .. } => {
                         self.balance = self.balance.try_add((*amount).into())?;
                     }
-                    Operation::CreateAccount { .. }
+                    Operation::OpenAccount { .. }
                     | Operation::CloseAccount
                     | Operation::ChangeOwner { .. } => (),
                 }

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -587,7 +587,8 @@ where
         with_confirmation: bool,
     ) -> Result<CertifiedRequest, failure::Error> {
         ensure!(
-            self.pending_request == None || self.pending_request.as_ref() == Some(&order),
+            self.pending_request.is_none()
+                || self.pending_request.as_ref().unwrap().request == order.request,
             "Client state has a different pending request",
         );
         ensure!(

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -18,21 +18,21 @@ pub type AsyncResult<'a, T, E> = future::BoxFuture<'a, Result<T, E>>;
 
 pub trait AuthorityClient {
     /// Initiate a new transfer to a FastPay or Primary account.
-    fn handle_transfer_order(
+    fn handle_request_order(
         &mut self,
-        order: TransferOrder,
+        order: RequestOrder,
     ) -> AsyncResult<AccountInfoResponse, FastPayError>;
 
-    /// Confirm a transfer to a FastPay or Primary account.
+    /// Confirm a request to a FastPay or Primary account.
     fn handle_confirmation_order(
         &mut self,
         order: ConfirmationOrder,
     ) -> AsyncResult<AccountInfoResponse, FastPayError>;
 
-    /// Handle information requests for this account.
-    fn handle_account_info_request(
+    /// Handle information queries for this account.
+    fn handle_account_info_query(
         &mut self,
-        request: AccountInfoRequest,
+        query: AccountInfoQuery,
     ) -> AsyncResult<AccountInfoResponse, FastPayError>;
 }
 
@@ -45,21 +45,21 @@ pub struct ClientState<AuthorityClient> {
     committee: Committee,
     /// How to talk to this committee.
     authority_clients: HashMap<AuthorityName, AuthorityClient>,
-    /// Expected sequence number for the next certified transfer.
-    /// This is also the number of transfer certificates that we have created.
+    /// Expected sequence number for the next certified request.
+    /// This is also the number of request certificates that we have created.
     next_sequence_number: SequenceNumber,
-    /// Pending transfer.
-    pending_transfer: Option<TransferOrder>,
+    /// Pending request.
+    pending_request: Option<RequestOrder>,
     /// Pending new key pair.
     pending_key_pair: Option<KeyPair>,
 
     // The remaining fields are used to minimize networking, and may not always be persisted locally.
-    /// Transfer certificates that we have created ("sent").
+    /// Request certificates that we have created ("sent").
     /// Normally, `sent_certificates` should contain one certificate for each index in `0..next_sequence_number`.
-    sent_certificates: Vec<CertifiedTransferOrder>,
+    sent_certificates: Vec<CertifiedRequestOrder>,
     /// Known received certificates, indexed by account_id and sequence number.
     /// TODO: API to search and download yet unknown `received_certificates`.
-    received_certificates: BTreeMap<(AccountId, SequenceNumber), CertifiedTransferOrder>,
+    received_certificates: BTreeMap<(AccountId, SequenceNumber), CertifiedRequestOrder>,
     /// The known spendable balance (including a possible initial funding, excluding unknown sent
     /// or received certificates).
     balance: Balance,
@@ -73,7 +73,7 @@ pub trait Client {
         amount: Amount,
         recipient: AccountId,
         user_data: UserData,
-    ) -> AsyncResult<CertifiedTransferOrder, failure::Error>;
+    ) -> AsyncResult<CertifiedRequestOrder, failure::Error>;
 
     /// Send money to a Primary account.
     fn transfer_to_primary(
@@ -81,12 +81,12 @@ pub trait Client {
         amount: Amount,
         recipient: PrimaryAddress,
         user_data: UserData,
-    ) -> AsyncResult<CertifiedTransferOrder, failure::Error>;
+    ) -> AsyncResult<CertifiedRequestOrder, failure::Error>;
 
     /// Receive money from FastPay.
     fn receive_from_fastpay(
         &mut self,
-        certificate: CertifiedTransferOrder,
+        certificate: CertifiedRequestOrder,
     ) -> AsyncResult<(), failure::Error>;
 
     /// Send money to a FastPay account.
@@ -97,7 +97,7 @@ pub trait Client {
         amount: Amount,
         recipient: AccountId,
         user_data: UserData,
-    ) -> AsyncResult<CertifiedTransferOrder, failure::Error>;
+    ) -> AsyncResult<CertifiedRequestOrder, failure::Error>;
 
     /// Find how much money we can spend.
     /// TODO: Currently, this value only reflects received transfers that were
@@ -113,8 +113,8 @@ impl<A> ClientState<A> {
         committee: Committee,
         authority_clients: HashMap<AuthorityName, A>,
         next_sequence_number: SequenceNumber,
-        sent_certificates: Vec<CertifiedTransferOrder>,
-        received_certificates: Vec<CertifiedTransferOrder>,
+        sent_certificates: Vec<CertifiedRequestOrder>,
+        received_certificates: Vec<CertifiedRequestOrder>,
         balance: Balance,
     ) -> Self {
         Self {
@@ -123,7 +123,7 @@ impl<A> ClientState<A> {
             committee,
             authority_clients,
             next_sequence_number,
-            pending_transfer: None,
+            pending_request: None,
             pending_key_pair: None,
             sent_certificates,
             received_certificates: received_certificates
@@ -146,15 +146,15 @@ impl<A> ClientState<A> {
         self.balance
     }
 
-    pub fn pending_transfer(&self) -> &Option<TransferOrder> {
-        &self.pending_transfer
+    pub fn pending_request(&self) -> &Option<RequestOrder> {
+        &self.pending_request
     }
 
-    pub fn sent_certificates(&self) -> &Vec<CertifiedTransferOrder> {
+    pub fn sent_certificates(&self) -> &Vec<CertifiedRequestOrder> {
         &self.sent_certificates
     }
 
-    pub fn received_certificates(&self) -> impl Iterator<Item = &CertifiedTransferOrder> {
+    pub fn received_certificates(&self) -> impl Iterator<Item = &CertifiedRequestOrder> {
         self.received_certificates.values()
     }
 }
@@ -181,32 +181,32 @@ where
     A: AuthorityClient + Send + Sync + 'static + Clone,
 {
     type Key = SequenceNumber;
-    type Value = Result<CertifiedTransferOrder, FastPayError>;
+    type Value = Result<CertifiedRequestOrder, FastPayError>;
 
     /// Try to find a certificate for the given account_id and sequence number.
     fn query(
         &mut self,
         sequence_number: SequenceNumber,
-    ) -> AsyncResult<CertifiedTransferOrder, FastPayError> {
+    ) -> AsyncResult<CertifiedRequestOrder, FastPayError> {
         Box::pin(async move {
-            let request = AccountInfoRequest {
+            let query = AccountInfoQuery {
                 account_id: self.account_id.clone(),
-                request_sequence_number: Some(sequence_number),
-                request_received_transfers_excluding_first_nth: None,
+                query_sequence_number: Some(sequence_number),
+                query_received_requests_excluding_first_nth: None,
             };
             // Sequentially try each authority in random order.
             self.authority_clients.shuffle(&mut rand::thread_rng());
             for client in self.authority_clients.iter_mut() {
-                let result = client.handle_account_info_request(request.clone()).await;
+                let result = client.handle_account_info_query(query.clone()).await;
                 if let Ok(AccountInfoResponse {
-                    requested_certificate: Some(certificate),
+                    queried_certificate: Some(certificate),
                     ..
                 }) = &result
                 {
                     if certificate.check(&self.committee).is_ok() {
                         let order = &certificate.value;
-                        if order.transfer.account_id == self.account_id
-                            && order.transfer.sequence_number == sequence_number
+                        if order.request.account_id == self.account_id
+                            && order.request.sequence_number == sequence_number
                         {
                             return Ok(certificate.clone());
                         }
@@ -218,10 +218,10 @@ where
     }
 }
 
-/// Used for communicate_transfers
+/// Used for communicate_requests
 #[derive(Clone)]
 enum CommunicateAction {
-    SendOrder(TransferOrder),
+    SendOrder(RequestOrder),
     SynchronizeNextSequenceNumber(SequenceNumber),
 }
 
@@ -230,11 +230,11 @@ where
     A: AuthorityClient + Send + Sync + 'static + Clone,
 {
     #[cfg(test)]
-    async fn request_certificate(
+    async fn query_certificate(
         &mut self,
         account_id: AccountId,
         sequence_number: SequenceNumber,
-    ) -> Result<CertifiedTransferOrder, FastPayError> {
+    ) -> Result<CertifiedRequestOrder, FastPayError> {
         CertificateRequester::new(
             self.committee.clone(),
             self.authority_clients.values().cloned().collect(),
@@ -251,16 +251,16 @@ where
         &mut self,
         account_id: AccountId,
     ) -> SequenceNumber {
-        let request = AccountInfoRequest {
+        let query = AccountInfoQuery {
             account_id,
-            request_sequence_number: None,
-            request_received_transfers_excluding_first_nth: None,
+            query_sequence_number: None,
+            query_received_requests_excluding_first_nth: None,
         };
         let numbers: futures::stream::FuturesUnordered<_> = self
             .authority_clients
             .iter_mut()
             .map(|(name, client)| {
-                let fut = client.handle_account_info_request(request.clone());
+                let fut = client.handle_account_info_query(query.clone());
                 async move {
                     match fut.await {
                         Ok(info) => Some((*name, info.next_sequence_number)),
@@ -278,16 +278,16 @@ where
     /// NOTE: This is only reliable in the synchronous model, with a sufficient timeout value.
     #[cfg(test)]
     async fn get_strong_majority_balance(&mut self) -> Balance {
-        let request = AccountInfoRequest {
+        let query = AccountInfoQuery {
             account_id: self.account_id.clone(),
-            request_sequence_number: None,
-            request_received_transfers_excluding_first_nth: None,
+            query_sequence_number: None,
+            query_received_requests_excluding_first_nth: None,
         };
         let numbers: futures::stream::FuturesUnordered<_> = self
             .authority_clients
             .iter_mut()
             .map(|(name, client)| {
-                let fut = client.handle_account_info_request(request.clone());
+                let fut = client.handle_account_info_query(query.clone());
                 async move {
                     match fut.await {
                         Ok(info) => Some((*name, info.balance)),
@@ -350,16 +350,16 @@ where
         bail!("Failed to communicate with a quorum of authorities (multiple errors)");
     }
 
-    /// Broadcast confirmation orders and optionally one more transfer order.
+    /// Broadcast confirmation orders and optionally one more request order.
     /// The corresponding sequence numbers should be consecutive and increasing.
-    async fn communicate_transfers(
+    async fn communicate_requests(
         &mut self,
         account_id: AccountId,
-        known_certificates: Vec<CertifiedTransferOrder>,
+        known_certificates: Vec<CertifiedRequestOrder>,
         action: CommunicateAction,
-    ) -> Result<Vec<CertifiedTransferOrder>, failure::Error> {
+    ) -> Result<Vec<CertifiedRequestOrder>, failure::Error> {
         let target_sequence_number = match &action {
-            CommunicateAction::SendOrder(order) => order.transfer.sequence_number,
+            CommunicateAction::SendOrder(order) => order.request.sequence_number,
             CommunicateAction::SynchronizeNextSequenceNumber(seq) => *seq,
         };
         let requester = CertificateRequester::new(
@@ -370,8 +370,8 @@ where
         let (task, mut handle) = Downloader::start(
             requester,
             known_certificates.into_iter().filter_map(|cert| {
-                if cert.value.transfer.account_id == account_id.clone() {
-                    Some((cert.value.transfer.sequence_number, Ok(cert)))
+                if cert.value.request.account_id == account_id.clone() {
+                    Some((cert.value.request.sequence_number, Ok(cert)))
                 } else {
                     None
                 }
@@ -386,12 +386,12 @@ where
                 let account_id = account_id.clone();
                 Box::pin(async move {
                     // Figure out which certificates this authority is missing.
-                    let request = AccountInfoRequest {
+                    let query = AccountInfoQuery {
                         account_id,
-                        request_sequence_number: None,
-                        request_received_transfers_excluding_first_nth: None,
+                        query_sequence_number: None,
+                        query_received_requests_excluding_first_nth: None,
                     };
-                    let response = client.handle_account_info_request(request).await?;
+                    let response = client.handle_account_info_query(query).await?;
                     let current_sequence_number = response.next_sequence_number;
                     // Download each missing certificate in reverse order using the downloader.
                     let mut missing_certificates = Vec::new();
@@ -414,9 +414,9 @@ where
                             .handle_confirmation_order(ConfirmationOrder::new(certificate))
                             .await?;
                     }
-                    // Send the transfer order (if any) and return a vote.
+                    // Send the request order (if any) and return a vote.
                     if let CommunicateAction::SendOrder(order) = action {
-                        let result = client.handle_transfer_order(order).await;
+                        let result = client.handle_request_order(order).await;
                         match result {
                             Ok(AccountInfoResponse {
                                 pending_confirmation: Some(signed_order),
@@ -424,13 +424,13 @@ where
                             }) => {
                                 fp_ensure!(
                                     signed_order.authority == name,
-                                    FastPayError::ErrorWhileProcessingTransferOrder
+                                    FastPayError::ErrorWhileProcessingRequestOrder
                                 );
                                 signed_order.check(committee)?;
                                 return Ok(Some(signed_order));
                             }
                             Err(err) => return Err(err),
-                            _ => return Err(FastPayError::ErrorWhileProcessingTransferOrder),
+                            _ => return Err(FastPayError::ErrorWhileProcessingRequestOrder),
                         }
                     }
                     Ok(None)
@@ -441,7 +441,7 @@ where
         handle.stop().await?;
         let mut certificates: Vec<_> = task.await.unwrap().filter_map(Result::ok).collect();
         if let CommunicateAction::SendOrder(order) = action {
-            let certificate = CertifiedTransferOrder {
+            let certificate = CertifiedRequestOrder {
                 value: order,
                 signatures: votes
                     .into_iter()
@@ -463,9 +463,7 @@ where
 
     /// Make sure we have all our certificates with sequence number
     /// in the range 0..self.next_sequence_number
-    async fn download_sent_certificates(
-        &self,
-    ) -> Result<Vec<CertifiedTransferOrder>, FastPayError> {
+    async fn download_sent_certificates(&self) -> Result<Vec<CertifiedRequestOrder>, FastPayError> {
         let mut requester = CertificateRequester::new(
             self.committee.clone(),
             self.authority_clients.values().cloned().collect(),
@@ -474,7 +472,7 @@ where
         let known_sequence_numbers: BTreeSet<_> = self
             .sent_certificates
             .iter()
-            .map(|cert| cert.value.transfer.sequence_number)
+            .map(|cert| cert.value.request.sequence_number)
             .collect();
         let mut sent_certificates = self.sent_certificates.clone();
         let mut number = SequenceNumber::from(0);
@@ -485,7 +483,7 @@ where
             }
             number = number.increment().unwrap_or_else(|_| SequenceNumber::max());
         }
-        sent_certificates.sort_by_key(|cert| cert.value.transfer.sequence_number);
+        sent_certificates.sort_by_key(|cert| cert.value.request.sequence_number);
         Ok(sent_certificates)
     }
 
@@ -495,7 +493,7 @@ where
         amount: Amount,
         recipient: Address,
         user_data: UserData,
-    ) -> Result<CertifiedTransferOrder, failure::Error> {
+    ) -> Result<CertifiedRequestOrder, failure::Error> {
         // Trying to overspend may block the account. To prevent this, we compare with
         // the balance as we know it.
         let safe_amount = self.get_spendable_amount().await?;
@@ -505,7 +503,7 @@ where
             amount,
             safe_amount
         );
-        let transfer = Transfer {
+        let request = Request {
             account_id: self.account_id.clone(),
             operation: Operation::Payment {
                 recipient,
@@ -514,9 +512,9 @@ where
             },
             sequence_number: self.next_sequence_number,
         };
-        let order = TransferOrder::new(transfer, &self.key_pair);
+        let order = RequestOrder::new(request, &self.key_pair);
         let certificate = self
-            .execute_transfer(order, /* with_confirmation */ true)
+            .execute_request(order, /* with_confirmation */ true)
             .await?;
         Ok(certificate)
     }
@@ -526,12 +524,12 @@ where
     /// We assume certificates to be valid and sent by us, and their sequence numbers to be unique.
     fn update_sent_certificates(
         &mut self,
-        sent_certificates: Vec<CertifiedTransferOrder>,
+        sent_certificates: Vec<CertifiedRequestOrder>,
     ) -> Result<(), FastPayError> {
         let mut new_balance = self.balance;
         let mut new_next_sequence_number = self.next_sequence_number;
         for new_cert in &sent_certificates {
-            match &new_cert.value.transfer.operation {
+            match &new_cert.value.request.operation {
                 Operation::Payment { amount, .. } => {
                     new_balance = new_balance.try_sub((*amount).into())?;
                 }
@@ -539,12 +537,12 @@ where
                 | Operation::CloseAccount
                 | Operation::ChangeOwner { .. } => (),
             }
-            if new_cert.value.transfer.sequence_number >= new_next_sequence_number {
+            if new_cert.value.request.sequence_number >= new_next_sequence_number {
                 assert_eq!(
-                    new_cert.value.transfer.sequence_number, new_next_sequence_number,
+                    new_cert.value.request.sequence_number, new_next_sequence_number,
                     "New certificates should be given in order"
                 );
-                if let Operation::ChangeOwner { new_owner } = &new_cert.value.transfer.operation {
+                if let Operation::ChangeOwner { new_owner } = &new_cert.value.request.operation {
                     // TODO: add client support for initiating key rotations
                     // TODO: support handing over the account to someone else.
                     // TODO: crash resistance + key storage
@@ -555,14 +553,14 @@ where
                 }
                 new_next_sequence_number = new_cert
                     .value
-                    .transfer
+                    .request
                     .sequence_number
                     .increment()
                     .unwrap_or_else(|_| SequenceNumber::max());
             }
         }
         for old_cert in &self.sent_certificates {
-            match &old_cert.value.transfer.operation {
+            match &old_cert.value.request.operation {
                 Operation::Payment { amount, .. } => {
                     new_balance = new_balance.try_add((*amount).into())?;
                 }
@@ -583,37 +581,37 @@ where
         Ok(())
     }
 
-    /// Execute (or retry) a transfer order. Update local balance.
-    async fn execute_transfer(
+    /// Execute (or retry) a request order. Update local balance.
+    async fn execute_request(
         &mut self,
-        order: TransferOrder,
+        order: RequestOrder,
         with_confirmation: bool,
-    ) -> Result<CertifiedTransferOrder, failure::Error> {
+    ) -> Result<CertifiedRequestOrder, failure::Error> {
         ensure!(
-            self.pending_transfer == None || self.pending_transfer.as_ref() == Some(&order),
-            "Client state has a different pending transfer",
+            self.pending_request == None || self.pending_request.as_ref() == Some(&order),
+            "Client state has a different pending request",
         );
         ensure!(
-            order.transfer.sequence_number == self.next_sequence_number,
+            order.request.sequence_number == self.next_sequence_number,
             "Unexpected sequence number"
         );
-        self.pending_transfer = Some(order.clone());
+        self.pending_request = Some(order.clone());
         let new_sent_certificates = self
-            .communicate_transfers(
+            .communicate_requests(
                 self.account_id.clone(),
                 self.sent_certificates.clone(),
                 CommunicateAction::SendOrder(order.clone()),
             )
             .await?;
         assert_eq!(new_sent_certificates.last().unwrap().value, order);
-        // Clear `pending_transfer` and update `sent_certificates`,
+        // Clear `pending_request` and update `sent_certificates`,
         // `balance`, and `next_sequence_number`. (Note that if we were using persistent
         // storage, we should ensure update atomicity in the eventuality of a crash.)
-        self.pending_transfer = None;
+        self.pending_request = None;
         self.update_sent_certificates(new_sent_certificates)?;
-        // Confirm last transfer certificate if needed.
+        // Confirm last request certificate if needed.
         if with_confirmation {
-            self.communicate_transfers(
+            self.communicate_requests(
                 self.account_id.clone(),
                 self.sent_certificates.clone(),
                 CommunicateAction::SynchronizeNextSequenceNumber(self.next_sequence_number),
@@ -633,7 +631,7 @@ where
         amount: Amount,
         recipient: AccountId,
         user_data: UserData,
-    ) -> AsyncResult<CertifiedTransferOrder, failure::Error> {
+    ) -> AsyncResult<CertifiedRequestOrder, failure::Error> {
         Box::pin(self.transfer(amount, Address::FastPay(recipient), user_data))
     }
 
@@ -642,15 +640,15 @@ where
         amount: Amount,
         recipient: PrimaryAddress,
         user_data: UserData,
-    ) -> AsyncResult<CertifiedTransferOrder, failure::Error> {
+    ) -> AsyncResult<CertifiedRequestOrder, failure::Error> {
         Box::pin(self.transfer(amount, Address::Primary(recipient), user_data))
     }
 
     fn get_spendable_amount(&mut self) -> AsyncResult<Amount, failure::Error> {
         Box::pin(async move {
-            if let Some(order) = self.pending_transfer.clone() {
-                // Finish executing the previous transfer.
-                self.execute_transfer(order, /* with_confirmation */ false)
+            if let Some(order) = self.pending_request.clone() {
+                // Finish executing the previous request.
+                self.execute_request(order, /* with_confirmation */ false)
                     .await?;
             }
             if self.sent_certificates.len() < self.next_sequence_number.into() {
@@ -669,17 +667,17 @@ where
 
     fn receive_from_fastpay(
         &mut self,
-        certificate: CertifiedTransferOrder,
+        certificate: CertifiedRequestOrder,
     ) -> AsyncResult<(), failure::Error> {
         Box::pin(async move {
             certificate.check(&self.committee)?;
-            let transfer = &certificate.value.transfer;
-            let account_id = &certificate.value.transfer.account_id;
-            match &transfer.operation {
+            let request = &certificate.value.request;
+            let account_id = &certificate.value.request.account_id;
+            match &request.operation {
                 Operation::Payment { recipient, .. } => {
                     ensure!(
                         recipient == &Address::FastPay(self.account_id.clone()), // TODO: avoid copy
-                        "Transfer should be received by us."
+                        "Request should be received by us."
                     );
                 }
                 Operation::OpenAccount { .. }
@@ -688,18 +686,18 @@ where
                     // TODO: decide what to do
                 }
             }
-            self.communicate_transfers(
+            self.communicate_requests(
                 account_id.clone(),
                 vec![certificate.clone()],
                 CommunicateAction::SynchronizeNextSequenceNumber(
-                    certificate.value.transfer.sequence_number.increment()?,
+                    certificate.value.request.sequence_number.increment()?,
                 ),
             )
             .await?;
             // Everything worked: update the local balance.
             let order = &certificate.value;
             if let btree_map::Entry::Vacant(entry) = self.received_certificates.entry(order.key()) {
-                match &transfer.operation {
+                match &request.operation {
                     Operation::Payment { amount, .. } => {
                         self.balance = self.balance.try_add((*amount).into())?;
                     }
@@ -718,9 +716,9 @@ where
         amount: Amount,
         recipient: AccountId,
         user_data: UserData,
-    ) -> AsyncResult<CertifiedTransferOrder, failure::Error> {
+    ) -> AsyncResult<CertifiedRequestOrder, failure::Error> {
         Box::pin(async move {
-            let transfer = Transfer {
+            let request = Request {
                 account_id: self.account_id.clone(),
                 operation: Operation::Payment {
                     recipient: Address::FastPay(recipient),
@@ -729,9 +727,9 @@ where
                 },
                 sequence_number: self.next_sequence_number,
             };
-            let order = TransferOrder::new(transfer, &self.key_pair);
+            let order = RequestOrder::new(request, &self.key_pair);
             let new_certificate = self
-                .execute_transfer(order, /* with_confirmation */ false)
+                .execute_request(order, /* with_confirmation */ false)
                 .await?;
             Ok(new_certificate)
         })

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -416,15 +416,15 @@ where
                         let result = client.handle_request_order(order).await;
                         match result {
                             Ok(AccountInfoResponse {
-                                pending_confirmation: Some(signed_order),
+                                pending: Some(vote),
                                 ..
                             }) => {
                                 fp_ensure!(
-                                    signed_order.authority == name,
+                                    vote.authority == name,
                                     FastPayError::ErrorWhileProcessingRequestOrder
                                 );
-                                signed_order.check(committee)?;
-                                return Ok(Some(signed_order));
+                                vote.check(committee)?;
+                                return Ok(Some(vote));
                             }
                             Err(err) => return Err(err),
                             _ => return Err(FastPayError::ErrorWhileProcessingRequestOrder),
@@ -443,9 +443,7 @@ where
                 signatures: votes
                     .into_iter()
                     .filter_map(|vote| match vote {
-                        Some(signed_order) => {
-                            Some((signed_order.authority, signed_order.signature))
-                        }
+                        Some(vote) => Some((vote.authority, vote.signature)),
                         None => None,
                     })
                     .collect(),

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -505,7 +505,7 @@ where
         );
         let request = Request {
             account_id: self.account_id.clone(),
-            operation: Operation::Payment {
+            operation: Operation::Transfer {
                 recipient,
                 amount,
                 user_data,
@@ -530,7 +530,7 @@ where
         let mut new_next_sequence_number = self.next_sequence_number;
         for new_cert in &sent_certificates {
             match &new_cert.value.operation {
-                Operation::Payment { amount, .. } => {
+                Operation::Transfer { amount, .. } => {
                     new_balance = new_balance.try_sub((*amount).into())?;
                 }
                 Operation::OpenAccount { .. }
@@ -560,7 +560,7 @@ where
         }
         for old_cert in &self.sent_certificates {
             match &old_cert.value.operation {
-                Operation::Payment { amount, .. } => {
+                Operation::Transfer { amount, .. } => {
                     new_balance = new_balance.try_add((*amount).into())?;
                 }
                 Operation::OpenAccount { .. }
@@ -673,7 +673,7 @@ where
             let request = &certificate.value;
             let account_id = &request.account_id;
             match &request.operation {
-                Operation::Payment { recipient, .. } => {
+                Operation::Transfer { recipient, .. } => {
                     ensure!(
                         recipient == &Address::FastPay(self.account_id.clone()), // TODO: avoid copy
                         "Request should be received by us."
@@ -698,7 +698,7 @@ where
             if let btree_map::Entry::Vacant(entry) = self.received_certificates.entry(request.key())
             {
                 match &request.operation {
-                    Operation::Payment { amount, .. } => {
+                    Operation::Transfer { amount, .. } => {
                         self.balance = self.balance.try_add((*amount).into())?;
                     }
                     Operation::OpenAccount { .. }
@@ -720,7 +720,7 @@ where
         Box::pin(async move {
             let request = Request {
                 account_id: self.account_id.clone(),
-                operation: Operation::Payment {
+                operation: Operation::Transfer {
                     recipient: Address::FastPay(recipient),
                     amount,
                     user_data,

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -534,6 +534,7 @@ where
                 }
                 Operation::OpenAccount { .. }
                 | Operation::CloseAccount
+                | Operation::Spend { .. }
                 | Operation::ChangeOwner { .. } => (),
             }
             if request.sequence_number >= new_next_sequence_number {
@@ -567,6 +568,7 @@ where
                 }
                 Operation::OpenAccount { .. }
                 | Operation::CloseAccount
+                | Operation::Spend { .. }
                 | Operation::ChangeOwner { .. } => (),
             }
         }
@@ -690,6 +692,7 @@ where
                 }
                 Operation::OpenAccount { .. }
                 | Operation::CloseAccount
+                | Operation::Spend { .. }
                 | Operation::ChangeOwner { .. } => {
                     // TODO: decide what to do
                 }
@@ -713,6 +716,7 @@ where
                     }
                     Operation::OpenAccount { .. }
                     | Operation::CloseAccount
+                    | Operation::Spend { .. }
                     | Operation::ChangeOwner { .. } => (),
                 }
                 entry.insert(certificate);

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -507,7 +507,7 @@ where
             },
             sequence_number: self.next_sequence_number,
         };
-        let order = RequestOrder::new(request, &self.key_pair);
+        let order = RequestOrder::new(request, &self.key_pair, Vec::new());
         let certificate = self
             .execute_request(order, /* with_confirmation */ true)
             .await?;
@@ -535,6 +535,7 @@ where
                 Operation::OpenAccount { .. }
                 | Operation::CloseAccount
                 | Operation::Spend { .. }
+                | Operation::SpendAndTransfer { .. }
                 | Operation::ChangeOwner { .. } => (),
             }
             if request.sequence_number >= new_next_sequence_number {
@@ -569,6 +570,7 @@ where
                 Operation::OpenAccount { .. }
                 | Operation::CloseAccount
                 | Operation::Spend { .. }
+                | Operation::SpendAndTransfer { .. }
                 | Operation::ChangeOwner { .. } => (),
             }
         }
@@ -693,6 +695,7 @@ where
                 Operation::OpenAccount { .. }
                 | Operation::CloseAccount
                 | Operation::Spend { .. }
+                | Operation::SpendAndTransfer { .. }
                 | Operation::ChangeOwner { .. } => {
                     // TODO: decide what to do
                 }
@@ -717,6 +720,7 @@ where
                     Operation::OpenAccount { .. }
                     | Operation::CloseAccount
                     | Operation::Spend { .. }
+                    | Operation::SpendAndTransfer { .. }
                     | Operation::ChangeOwner { .. } => (),
                 }
                 entry.insert(certificate);
@@ -741,7 +745,7 @@ where
                 },
                 sequence_number: self.next_sequence_number,
             };
-            let order = RequestOrder::new(request, &self.key_pair);
+            let order = RequestOrder::new(request, &self.key_pair, Vec::new());
             let new_certificate = self
                 .execute_request(order, /* with_confirmation */ false)
                 .await?;

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -54,7 +54,7 @@ pub enum FastPayError {
         display = "Cannot initiate transfer while a transfer order is still pending confirmation: {:?}",
         pending_confirmation
     )]
-    PreviousRequestMustBeConfirmedFirst { pending_confirmation: Request },
+    PreviousRequestMustBeConfirmedFirst { pending_confirmation: Value },
     #[fail(display = "Request order was processed but no signature was produced by authority")]
     ErrorWhileProcessingRequestOrder,
     #[fail(
@@ -100,6 +100,8 @@ pub enum FastPayError {
     InvalidDecoding,
     #[fail(display = "Unexpected message.")]
     UnexpectedMessage,
+    #[fail(display = "InvalidConfirmationOrder.")]
+    InvalidConfirmationOrder,
     #[fail(display = "Network error while querying service: {:?}.", error)]
     ClientIoError { error: String },
 }

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -54,7 +54,7 @@ pub enum FastPayError {
         display = "Cannot initiate transfer while a transfer order is still pending confirmation: {:?}",
         pending_confirmation
     )]
-    PreviousRequestMustBeConfirmedFirst { pending_confirmation: RequestOrder },
+    PreviousRequestMustBeConfirmedFirst { pending_confirmation: Request },
     #[fail(display = "Request order was processed but no signature was produced by authority")]
     ErrorWhileProcessingRequestOrder,
     #[fail(

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -54,15 +54,15 @@ pub enum FastPayError {
         display = "Cannot initiate transfer while a transfer order is still pending confirmation: {:?}",
         pending_confirmation
     )]
-    PreviousTransferMustBeConfirmedFirst { pending_confirmation: TransferOrder },
-    #[fail(display = "Transfer order was processed but no signature was produced by authority")]
-    ErrorWhileProcessingTransferOrder,
+    PreviousRequestMustBeConfirmedFirst { pending_confirmation: RequestOrder },
+    #[fail(display = "Request order was processed but no signature was produced by authority")]
+    ErrorWhileProcessingRequestOrder,
     #[fail(
         display = "An invalid answer was returned by the authority while requesting a certificate"
     )]
     ErrorWhileRequestingCertificate,
     #[fail(
-        display = "Cannot confirm a transfer while previous transfer orders are still pending confirmation: {:?}",
+        display = "Cannot confirm a request while previous request orders are still pending confirmation: {:?}",
         current_sequence_number
     )]
     MissingEarlierConfirmations {
@@ -78,7 +78,7 @@ pub enum FastPayError {
     UnknownSenderAccount(AccountId),
     #[fail(display = "Signatures in a certificate must be from different authorities.")]
     CertificateAuthorityReuse,
-    #[fail(display = "Sequence numbers above the maximal value are not usable for transfers.")]
+    #[fail(display = "Sequence numbers above the maximal value are not usable for requests.")]
     InvalidSequenceNumber,
     #[fail(display = "Sequence number overflow.")]
     SequenceOverflow,

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -102,6 +102,8 @@ pub enum FastPayError {
     UnexpectedMessage,
     #[fail(display = "InvalidConfirmationOrder.")]
     InvalidConfirmationOrder,
+    #[fail(display = "InvalidCoinCreationOrder.")]
+    InvalidCoinCreationOrder,
     #[fail(display = "Network error while querying service: {:?}.", error)]
     ClientIoError { error: String },
 }

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{base_types::*, messages::*};
+use crate::{base_types::*, messages::Value};
 use failure::Fail;
 use serde::{Deserialize, Serialize};
 
@@ -100,10 +100,12 @@ pub enum FastPayError {
     InvalidDecoding,
     #[fail(display = "Unexpected message.")]
     UnexpectedMessage,
-    #[fail(display = "InvalidConfirmationOrder.")]
+    #[fail(display = "Invalid confirmation order.")]
     InvalidConfirmationOrder,
-    #[fail(display = "InvalidCoinCreationOrder.")]
+    #[fail(display = "Invalid coin creation order.")]
     InvalidCoinCreationOrder,
+    #[fail(display = "Invalid coin.")]
+    InvalidCoin,
     #[fail(display = "Network error while querying service: {:?}.", error)]
     ClientIoError { error: String },
 }

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -52,9 +52,9 @@ pub enum FastPayError {
     InvalidNewAccountId(AccountId),
     #[fail(
         display = "Cannot initiate transfer while a transfer order is still pending confirmation: {:?}",
-        pending_confirmation
+        pending
     )]
-    PreviousRequestMustBeConfirmedFirst { pending_confirmation: Value },
+    PreviousRequestMustBeConfirmedFirst { pending: Value },
     #[fail(display = "Request order was processed but no signature was produced by authority")]
     ErrorWhileProcessingRequestOrder,
     #[fail(

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -100,6 +100,7 @@ impl FastPaySmartContract for FastPaySmartContractState {
             Operation::Transfer { .. }
             | Operation::OpenAccount { .. }
             | Operation::CloseAccount
+            | Operation::Spend { .. }
             | Operation::ChangeOwner { .. } => {
                 failure::bail!("Invalid redeem transaction");
             }

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -69,8 +69,11 @@ impl FastPaySmartContract for FastPaySmartContractState {
         &mut self,
         transaction: RedeemTransaction,
     ) -> Result<(), failure::Error> {
-        transaction.request_certificate.check(&self.committee)?;
-        let request = transaction.request_certificate.value;
+        transaction.certificate.check(&self.committee)?;
+        let request = match &transaction.certificate.value {
+            Value::Confirm(r) => r,
+            _ => failure::bail!("Invalid redeem transaction"),
+        };
         match &request.operation {
             Operation::Transfer {
                 amount,

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -1,13 +1,23 @@
 // Copyright (c) Facebook Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! This module is sketching a FastPay smart contract on a primary chain.
+
 use super::{base_types::*, committee::Committee, messages::*};
 use failure::ensure;
 use std::collections::BTreeMap;
+use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 #[path = "unit_tests/fastpay_smart_contract_tests.rs"]
 mod fastpay_smart_contract_tests;
+
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub struct FundingTransaction {
+    pub recipient: AccountId,
+    pub primary_coins: Amount,
+    // TODO: Authenticated by Primary sender.
+}
 
 #[derive(Eq, PartialEq, Clone, Hash, Debug)]
 pub struct AccountState {

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -70,8 +70,7 @@ impl FastPaySmartContract for FastPaySmartContractState {
         transaction: RedeemTransaction,
     ) -> Result<(), failure::Error> {
         transaction.request_certificate.check(&self.committee)?;
-        let order = transaction.request_certificate.value;
-        let request = &order.request;
+        let request = transaction.request_certificate.value;
         match &request.operation {
             Operation::Payment {
                 amount,
@@ -84,7 +83,7 @@ impl FastPaySmartContract for FastPaySmartContractState {
                 );
                 let account = self
                     .accounts
-                    .entry(order.request.account_id.clone())
+                    .entry(request.account_id.clone())
                     .or_insert_with(AccountState::new);
                 ensure!(
                     account.last_redeemed < Some(request.sequence_number),
@@ -92,7 +91,7 @@ impl FastPaySmartContract for FastPaySmartContractState {
                 );
                 account.last_redeemed = Some(request.sequence_number);
                 self.total_balance = self.total_balance.try_sub(*amount)?;
-                // Request Primary coins to order.recipient
+                // Request Primary coins to recipient
                 Ok(())
             }
             Operation::Payment { .. }

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -72,7 +72,7 @@ impl FastPaySmartContract for FastPaySmartContractState {
         transaction.request_certificate.check(&self.committee)?;
         let request = transaction.request_certificate.value;
         match &request.operation {
-            Operation::Payment {
+            Operation::Transfer {
                 amount,
                 recipient: Address::Primary(_),
                 ..
@@ -94,7 +94,7 @@ impl FastPaySmartContract for FastPaySmartContractState {
                 // Request Primary coins to recipient
                 Ok(())
             }
-            Operation::Payment { .. }
+            Operation::Transfer { .. }
             | Operation::OpenAccount { .. }
             | Operation::CloseAccount
             | Operation::ChangeOwner { .. } => {

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -5,8 +5,8 @@
 
 use super::{base_types::*, committee::Committee, messages::*};
 use failure::ensure;
-use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[cfg(test)]
 #[path = "unit_tests/fastpay_smart_contract_tests.rs"]
@@ -17,6 +17,18 @@ pub struct FundingTransaction {
     pub recipient: AccountId,
     pub primary_coins: Amount,
     // TODO: Authenticated by Primary sender.
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub struct RedeemTransaction {
+    pub certificate: Certificate,
+}
+
+impl RedeemTransaction {
+    pub fn new(certificate: Certificate) -> Self {
+        Self { certificate }
+    }
 }
 
 #[derive(Eq, PartialEq, Clone, Hash, Debug)]
@@ -95,13 +107,14 @@ impl FastPaySmartContract for FastPaySmartContractState {
         account.last_redeemed = Some(request.sequence_number);
         let amount = match &request.operation {
             Operation::Transfer {
-                amount,
                 recipient: Address::Primary(_),
+                amount,
                 ..
             }
             | Operation::SpendAndTransfer {
                 recipient: Address::Primary(_),
                 amount,
+                ..
             } => *amount,
             Operation::Transfer { .. }
             | Operation::SpendAndTransfer { .. }

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -69,10 +69,10 @@ impl FastPaySmartContract for FastPaySmartContractState {
         &mut self,
         transaction: RedeemTransaction,
     ) -> Result<(), failure::Error> {
-        transaction.transfer_certificate.check(&self.committee)?;
-        let order = transaction.transfer_certificate.value;
-        let transfer = &order.transfer;
-        match &transfer.operation {
+        transaction.request_certificate.check(&self.committee)?;
+        let order = transaction.request_certificate.value;
+        let request = &order.request;
+        match &request.operation {
             Operation::Payment {
                 amount,
                 recipient: Address::Primary(_),
@@ -84,15 +84,15 @@ impl FastPaySmartContract for FastPaySmartContractState {
                 );
                 let account = self
                     .accounts
-                    .entry(order.transfer.account_id.clone())
+                    .entry(order.request.account_id.clone())
                     .or_insert_with(AccountState::new);
                 ensure!(
-                    account.last_redeemed < Some(transfer.sequence_number),
-                    "Transfer certificates to Primary must have increasing sequence numbers.",
+                    account.last_redeemed < Some(request.sequence_number),
+                    "Request certificates to Primary must have increasing sequence numbers.",
                 );
-                account.last_redeemed = Some(transfer.sequence_number);
+                account.last_redeemed = Some(request.sequence_number);
                 self.total_balance = self.total_balance.try_sub(*amount)?;
-                // Transfer Primary coins to order.recipient
+                // Request Primary coins to order.recipient
                 Ok(())
             }
             Operation::Payment { .. }

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -96,7 +96,7 @@ impl FastPaySmartContract for FastPaySmartContractState {
                 Ok(())
             }
             Operation::Payment { .. }
-            | Operation::CreateAccount { .. }
+            | Operation::OpenAccount { .. }
             | Operation::CloseAccount
             | Operation::ChangeOwner { .. } => {
                 failure::bail!("Invalid redeem transaction");

--- a/fastpay_core/src/generate_format.rs
+++ b/fastpay_core/src/generate_format.rs
@@ -16,6 +16,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<messages::Address>(&samples)?;
     tracer.trace_type::<messages::Operation>(&samples)?;
     tracer.trace_type::<messages::Value>(&samples)?;
+    tracer.trace_type::<messages::Coin>(&samples)?;
     tracer.trace_type::<messages::CrossShardRequest>(&samples)?;
     tracer.trace_type::<messages::ConfirmationOutcome>(&samples)?;
     tracer.trace_type::<error::FastPayError>(&samples)?;

--- a/fastpay_core/src/generate_format.rs
+++ b/fastpay_core/src/generate_format.rs
@@ -18,7 +18,6 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<messages::Value>(&samples)?;
     tracer.trace_type::<messages::Coin>(&samples)?;
     tracer.trace_type::<messages::CrossShardRequest>(&samples)?;
-    tracer.trace_type::<messages::ConfirmationOutcome>(&samples)?;
     tracer.trace_type::<error::FastPayError>(&samples)?;
     tracer.trace_type::<serialize::SerializedMessage>(&samples)?;
     tracer.registry()

--- a/fastpay_core/src/generate_format.rs
+++ b/fastpay_core/src/generate_format.rs
@@ -15,6 +15,7 @@ fn get_registry() -> Result<Registry> {
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<messages::Address>(&samples)?;
     tracer.trace_type::<messages::Operation>(&samples)?;
+    tracer.trace_type::<messages::Value>(&samples)?;
     tracer.trace_type::<messages::CrossShardRequest>(&samples)?;
     tracer.trace_type::<messages::ConfirmationOutcome>(&samples)?;
     tracer.trace_type::<error::FastPayError>(&samples)?;

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -11,13 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub struct FundingTransaction {
-    pub recipient: AccountId,
-    pub primary_coins: Amount,
-    // TODO: Authenticated by Primary sender.
-}
-
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct PrimarySynchronizationOrder {
     pub recipient: AccountId,
     pub amount: Amount,

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -8,10 +8,7 @@ use super::{base_types::*, committee::Committee, error::*};
 mod messages_tests;
 
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashSet,
-    hash::{Hash, Hasher},
-};
+use std::collections::HashSet;
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct FundingTransaction {
@@ -71,44 +68,51 @@ pub struct Request {
     pub sequence_number: SequenceNumber,
 }
 
-#[derive(Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct RequestOrder {
     pub request: Request,
     pub owner: AccountOwner,
     pub signature: Signature,
 }
 
-#[derive(Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct SignedRequest {
     pub value: Request,
     pub authority: AuthorityName,
     pub signature: Signature,
 }
 
-#[derive(Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct CertifiedRequest {
     pub value: Request,
     pub signatures: Vec<(AuthorityName, Signature)>,
 }
 
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct RedeemTransaction {
     pub request_certificate: CertifiedRequest,
 }
 
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct ConfirmationOrder {
     pub request_certificate: CertifiedRequest,
 }
 
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct AccountInfoQuery {
     pub account_id: AccountId,
     pub query_sequence_number: Option<SequenceNumber>,
     pub query_received_requests_excluding_first_nth: Option<usize>,
 }
 
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct AccountInfoResponse {
     pub account_id: AccountId,
     pub owner: Option<AccountOwner>,
@@ -126,58 +130,10 @@ pub enum ConfirmationOutcome {
     Cancel,
 }
 
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct CrossShardRequest {
     pub certificate: CertifiedRequest,
-}
-
-impl Hash for RequestOrder {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.request.hash(state);
-        self.owner.hash(state);
-    }
-}
-
-impl PartialEq for RequestOrder {
-    fn eq(&self, other: &Self) -> bool {
-        self.request == other.request && self.owner == other.owner
-    }
-}
-
-impl Hash for SignedRequest {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.value.hash(state);
-        self.authority.hash(state);
-    }
-}
-
-impl PartialEq for SignedRequest {
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value && self.authority == other.authority
-    }
-}
-
-// TODO: review this
-impl Hash for CertifiedRequest {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.value.hash(state);
-        self.signatures.len().hash(state);
-        for (name, _) in self.signatures.iter() {
-            name.hash(state);
-        }
-    }
-}
-
-impl PartialEq for CertifiedRequest {
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value
-            && self.signatures.len() == other.signatures.len()
-            && self
-                .signatures
-                .iter()
-                .map(|(name, _)| name)
-                .eq(other.signatures.iter().map(|(name, _)| name))
-    }
 }
 
 impl Request {

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -215,7 +215,11 @@ impl RequestOrder {
         }
     }
 
-    pub fn check_signature(&self) -> Result<(), FastPayError> {
+    pub fn check(&self, authentication_method: &Option<AccountOwner>) -> Result<(), FastPayError> {
+        fp_ensure!(
+            authentication_method == &Some(self.owner),
+            FastPayError::InvalidOwner
+        );
         self.signature.check(&self.request, self.owner)
     }
 }

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -35,7 +35,7 @@ pub enum Address {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum Operation {
-    Payment {
+    Transfer {
         recipient: Address,
         amount: Amount,
         user_data: UserData,
@@ -54,12 +54,12 @@ impl Operation {
     pub fn recipient(&self) -> Option<&AccountId> {
         use Operation::*;
         match self {
-            Payment {
+            Transfer {
                 recipient: Address::FastPay(id),
                 ..
             } => Some(id),
             OpenAccount { new_id, .. } => Some(new_id),
-            Operation::CloseAccount | Payment { .. } | ChangeOwner { .. } => None,
+            Operation::CloseAccount | Transfer { .. } | ChangeOwner { .. } => None,
         }
     }
 }
@@ -192,14 +192,14 @@ impl Request {
 impl Request {
     pub(crate) fn amount(&self) -> Option<Amount> {
         match &self.operation {
-            Operation::Payment { amount, .. } => Some(*amount),
+            Operation::Transfer { amount, .. } => Some(*amount),
             _ => None,
         }
     }
 
     pub(crate) fn amount_mut(&mut self) -> Option<&mut Amount> {
         match &mut self.operation {
-            Operation::Payment { amount, .. } => Some(amount),
+            Operation::Transfer { amount, .. } => Some(amount),
             _ => None,
         }
     }

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -124,7 +124,7 @@ pub struct AccountInfoResponse {
     pub owner: Option<AccountOwner>,
     pub balance: Balance,
     pub next_sequence_number: SequenceNumber,
-    pub pending_confirmation: Option<Vote>,
+    pub pending: Option<Vote>,
     pub queried_certificate: Option<Certificate>,
     pub queried_received_requests: Vec<Certificate>,
 }

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -40,7 +40,7 @@ pub enum Operation {
         amount: Amount,
         user_data: UserData,
     },
-    CreateAccount {
+    OpenAccount {
         new_id: AccountId,
         new_owner: AccountOwner,
     },
@@ -58,7 +58,7 @@ impl Operation {
                 recipient: Address::FastPay(id),
                 ..
             } => Some(id),
-            CreateAccount { new_id, .. } => Some(new_id),
+            OpenAccount { new_id, .. } => Some(new_id),
             Operation::CloseAccount | Payment { .. } | ChangeOwner { .. } => None,
         }
     }

--- a/fastpay_core/src/serialize.rs
+++ b/fastpay_core/src/serialize.rs
@@ -13,11 +13,11 @@ mod serialize_tests;
 
 #[derive(Serialize, Deserialize)]
 pub enum SerializedMessage {
-    Order(Box<TransferOrder>),
-    Vote(Box<SignedTransferOrder>),
-    Confirmation(Box<CertifiedTransferOrder>),
+    Order(Box<RequestOrder>),
+    Vote(Box<SignedRequestOrder>),
+    Confirmation(Box<CertifiedRequestOrder>),
     Error(Box<FastPayError>),
-    InfoRequest(Box<AccountInfoRequest>),
+    InfoQuery(Box<AccountInfoQuery>),
     InfoResponse(Box<AccountInfoResponse>),
     // Internal to an authority
     CrossShardRequest(Box<CrossShardRequest>),
@@ -28,11 +28,11 @@ pub enum SerializedMessage {
 // so that the variant tags match.
 #[derive(Serialize)]
 enum ShallowSerializedMessage<'a> {
-    Order(&'a TransferOrder),
-    Vote(&'a SignedTransferOrder),
-    Cert(&'a CertifiedTransferOrder),
+    Order(&'a RequestOrder),
+    Vote(&'a SignedRequestOrder),
+    Cert(&'a CertifiedRequestOrder),
     Error(&'a FastPayError),
-    InfoRequest(&'a AccountInfoRequest),
+    InfoQuery(&'a AccountInfoQuery),
     InfoResponse(&'a AccountInfoResponse),
     // Internal to an authority
     CrossShardRequest(&'a CrossShardRequest),
@@ -60,13 +60,13 @@ pub fn serialize_message(msg: &SerializedMessage) -> Vec<u8> {
     serialize(msg)
 }
 
-pub fn serialize_transfer_order(value: &TransferOrder) -> Vec<u8> {
+pub fn serialize_request_order(value: &RequestOrder) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Order(value))
 }
 
-pub fn serialize_transfer_order_into<W>(
+pub fn serialize_request_order_into<W>(
     writer: W,
-    value: &TransferOrder,
+    value: &RequestOrder,
 ) -> Result<(), failure::Error>
 where
     W: std::io::Write,
@@ -78,13 +78,13 @@ pub fn serialize_error(value: &FastPayError) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Error(value))
 }
 
-pub fn serialize_cert(value: &CertifiedTransferOrder) -> Vec<u8> {
+pub fn serialize_cert(value: &CertifiedRequestOrder) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Cert(value))
 }
 
 pub fn serialize_cert_into<W>(
     writer: W,
-    value: &CertifiedTransferOrder,
+    value: &CertifiedRequestOrder,
 ) -> Result<(), failure::Error>
 where
     W: std::io::Write,
@@ -92,8 +92,8 @@ where
     serialize_into(writer, &ShallowSerializedMessage::Cert(value))
 }
 
-pub fn serialize_info_request(value: &AccountInfoRequest) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::InfoRequest(value))
+pub fn serialize_info_query(value: &AccountInfoQuery) -> Vec<u8> {
+    serialize(&ShallowSerializedMessage::InfoQuery(value))
 }
 
 pub fn serialize_info_response(value: &AccountInfoResponse) -> Vec<u8> {
@@ -104,11 +104,11 @@ pub fn serialize_cross_shard_request(value: &CrossShardRequest) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::CrossShardRequest(value))
 }
 
-pub fn serialize_vote(value: &SignedTransferOrder) -> Vec<u8> {
+pub fn serialize_vote(value: &SignedRequestOrder) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Vote(value))
 }
 
-pub fn serialize_vote_into<W>(writer: W, value: &SignedTransferOrder) -> Result<(), failure::Error>
+pub fn serialize_vote_into<W>(writer: W, value: &SignedRequestOrder) -> Result<(), failure::Error>
 where
     W: std::io::Write,
 {

--- a/fastpay_core/src/serialize.rs
+++ b/fastpay_core/src/serialize.rs
@@ -14,8 +14,8 @@ mod serialize_tests;
 #[derive(Serialize, Deserialize)]
 pub enum SerializedMessage {
     Order(Box<RequestOrder>),
-    Vote(Box<SignedRequestOrder>),
-    Confirmation(Box<CertifiedRequestOrder>),
+    Vote(Box<SignedRequest>),
+    Confirmation(Box<CertifiedRequest>),
     Error(Box<FastPayError>),
     InfoQuery(Box<AccountInfoQuery>),
     InfoResponse(Box<AccountInfoResponse>),
@@ -29,8 +29,8 @@ pub enum SerializedMessage {
 #[derive(Serialize)]
 enum ShallowSerializedMessage<'a> {
     Order(&'a RequestOrder),
-    Vote(&'a SignedRequestOrder),
-    Cert(&'a CertifiedRequestOrder),
+    Vote(&'a SignedRequest),
+    Cert(&'a CertifiedRequest),
     Error(&'a FastPayError),
     InfoQuery(&'a AccountInfoQuery),
     InfoResponse(&'a AccountInfoResponse),
@@ -78,14 +78,11 @@ pub fn serialize_error(value: &FastPayError) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Error(value))
 }
 
-pub fn serialize_cert(value: &CertifiedRequestOrder) -> Vec<u8> {
+pub fn serialize_cert(value: &CertifiedRequest) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Cert(value))
 }
 
-pub fn serialize_cert_into<W>(
-    writer: W,
-    value: &CertifiedRequestOrder,
-) -> Result<(), failure::Error>
+pub fn serialize_cert_into<W>(writer: W, value: &CertifiedRequest) -> Result<(), failure::Error>
 where
     W: std::io::Write,
 {
@@ -104,11 +101,11 @@ pub fn serialize_cross_shard_request(value: &CrossShardRequest) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::CrossShardRequest(value))
 }
 
-pub fn serialize_vote(value: &SignedRequestOrder) -> Vec<u8> {
+pub fn serialize_vote(value: &SignedRequest) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Vote(value))
 }
 
-pub fn serialize_vote_into<W>(writer: W, value: &SignedRequestOrder) -> Result<(), failure::Error>
+pub fn serialize_vote_into<W>(writer: W, value: &SignedRequest) -> Result<(), failure::Error>
 where
     W: std::io::Write,
 {

--- a/fastpay_core/src/serialize.rs
+++ b/fastpay_core/src/serialize.rs
@@ -13,12 +13,14 @@ mod serialize_tests;
 
 #[derive(Serialize, Deserialize)]
 pub enum SerializedMessage {
-    Order(Box<RequestOrder>),
+    RequestOrder(Box<RequestOrder>),
     Vote(Box<Vote>),
     Certificate(Box<Certificate>),
     Error(Box<FastPayError>),
     InfoQuery(Box<AccountInfoQuery>),
     InfoResponse(Box<AccountInfoResponse>),
+    CoinCreationOrder(Box<CoinCreationOrder>),
+    Votes(Vec<Vote>),
     // Internal to an authority
     CrossShardRequest(Box<CrossShardRequest>),
 }
@@ -28,12 +30,14 @@ pub enum SerializedMessage {
 // so that the variant tags match.
 #[derive(Serialize)]
 enum ShallowSerializedMessage<'a> {
-    Order(&'a RequestOrder),
+    RequestOrder(&'a RequestOrder),
     Vote(&'a Vote),
     Certificate(&'a Certificate),
     Error(&'a FastPayError),
     InfoQuery(&'a AccountInfoQuery),
     InfoResponse(&'a AccountInfoResponse),
+    CoinCreationOrder(&'a CoinCreationOrder),
+    Votes(&'a [Vote]),
     // Internal to an authority
     CrossShardRequest(&'a CrossShardRequest),
 }
@@ -61,7 +65,7 @@ pub fn serialize_message(msg: &SerializedMessage) -> Vec<u8> {
 }
 
 pub fn serialize_request_order(value: &RequestOrder) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::Order(value))
+    serialize(&ShallowSerializedMessage::RequestOrder(value))
 }
 
 pub fn serialize_request_order_into<W>(
@@ -71,7 +75,7 @@ pub fn serialize_request_order_into<W>(
 where
     W: std::io::Write,
 {
-    serialize_into(writer, &ShallowSerializedMessage::Order(value))
+    serialize_into(writer, &ShallowSerializedMessage::RequestOrder(value))
 }
 
 pub fn serialize_error(value: &FastPayError) -> Vec<u8> {
@@ -99,6 +103,14 @@ pub fn serialize_info_response(value: &AccountInfoResponse) -> Vec<u8> {
 
 pub fn serialize_cross_shard_request(value: &CrossShardRequest) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::CrossShardRequest(value))
+}
+
+pub fn serialize_coin_creation_order(value: &CoinCreationOrder) -> Vec<u8> {
+    serialize(&ShallowSerializedMessage::CoinCreationOrder(value))
+}
+
+pub fn serialize_votes(value: &[Vote]) -> Vec<u8> {
+    serialize(&ShallowSerializedMessage::Votes(value))
 }
 
 pub fn serialize_vote(value: &Vote) -> Vec<u8> {

--- a/fastpay_core/src/serialize.rs
+++ b/fastpay_core/src/serialize.rs
@@ -14,8 +14,8 @@ mod serialize_tests;
 #[derive(Serialize, Deserialize)]
 pub enum SerializedMessage {
     Order(Box<RequestOrder>),
-    Vote(Box<SignedRequest>),
-    Confirmation(Box<CertifiedRequest>),
+    Vote(Box<Vote>),
+    Certificate(Box<Certificate>),
     Error(Box<FastPayError>),
     InfoQuery(Box<AccountInfoQuery>),
     InfoResponse(Box<AccountInfoResponse>),
@@ -29,8 +29,8 @@ pub enum SerializedMessage {
 #[derive(Serialize)]
 enum ShallowSerializedMessage<'a> {
     Order(&'a RequestOrder),
-    Vote(&'a SignedRequest),
-    Cert(&'a CertifiedRequest),
+    Vote(&'a Vote),
+    Certificate(&'a Certificate),
     Error(&'a FastPayError),
     InfoQuery(&'a AccountInfoQuery),
     InfoResponse(&'a AccountInfoResponse),
@@ -78,15 +78,15 @@ pub fn serialize_error(value: &FastPayError) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Error(value))
 }
 
-pub fn serialize_cert(value: &CertifiedRequest) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::Cert(value))
+pub fn serialize_cert(value: &Certificate) -> Vec<u8> {
+    serialize(&ShallowSerializedMessage::Certificate(value))
 }
 
-pub fn serialize_cert_into<W>(writer: W, value: &CertifiedRequest) -> Result<(), failure::Error>
+pub fn serialize_cert_into<W>(writer: W, value: &Certificate) -> Result<(), failure::Error>
 where
     W: std::io::Write,
 {
-    serialize_into(writer, &ShallowSerializedMessage::Cert(value))
+    serialize_into(writer, &ShallowSerializedMessage::Certificate(value))
 }
 
 pub fn serialize_info_query(value: &AccountInfoQuery) -> Vec<u8> {
@@ -101,11 +101,11 @@ pub fn serialize_cross_shard_request(value: &CrossShardRequest) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::CrossShardRequest(value))
 }
 
-pub fn serialize_vote(value: &SignedRequest) -> Vec<u8> {
+pub fn serialize_vote(value: &Vote) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Vote(value))
 }
 
-pub fn serialize_vote_into<W>(writer: W, value: &SignedRequest) -> Result<(), failure::Error>
+pub fn serialize_vote_into<W>(writer: W, value: &Vote) -> Result<(), failure::Error>
 where
     W: std::io::Write,
 {

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -4,21 +4,21 @@
 use super::*;
 
 #[test]
-fn test_handle_transfer_order_bad_signature() {
+fn test_handle_request_order_bad_signature() {
     let sender_key_pair = get_key_pair();
     let recipient = Address::FastPay(dbg_account(2));
     let mut state = init_state_with_accounts(vec![
         (dbg_account(1), sender_key_pair.public(), Balance::from(5)),
         (dbg_account(2), dbg_addr(2), Balance::from(0)),
     ]);
-    let transfer_order =
-        init_transfer_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
+    let request_order =
+        init_request_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
     let unknown_key_pair = get_key_pair();
-    let mut bad_signature_transfer_order = transfer_order.clone();
-    bad_signature_transfer_order.signature =
-        Signature::new(&transfer_order.transfer, &unknown_key_pair);
+    let mut bad_signature_request_order = request_order.clone();
+    bad_signature_request_order.signature =
+        Signature::new(&request_order.request, &unknown_key_pair);
     assert!(state
-        .handle_transfer_order(bad_signature_transfer_order)
+        .handle_request_order(bad_signature_request_order)
         .is_err());
     assert!(state
         .accounts
@@ -29,18 +29,18 @@ fn test_handle_transfer_order_bad_signature() {
 }
 
 #[test]
-fn test_handle_transfer_order_zero_amount() {
+fn test_handle_request_order_zero_amount() {
     let sender_key_pair = get_key_pair();
     let recipient = Address::FastPay(dbg_account(2));
     let mut state = init_state_with_accounts(vec![
         (dbg_account(1), sender_key_pair.public(), Balance::from(5)),
         (dbg_account(2), dbg_addr(2), Balance::from(0)),
     ]);
-    // test transfer non-positive amount
-    let zero_amount_transfer_order =
-        init_transfer_order(dbg_account(1), &sender_key_pair, recipient, Amount::zero());
+    // test request non-positive amount
+    let zero_amount_request_order =
+        init_request_order(dbg_account(1), &sender_key_pair, recipient, Amount::zero());
     assert!(state
-        .handle_transfer_order(zero_amount_transfer_order)
+        .handle_request_order(zero_amount_request_order)
         .is_err());
     assert!(state
         .accounts
@@ -51,20 +51,20 @@ fn test_handle_transfer_order_zero_amount() {
 }
 
 #[test]
-fn test_handle_transfer_order_unknown_sender() {
+fn test_handle_request_order_unknown_sender() {
     let sender_key_pair = get_key_pair();
     let recipient = Address::FastPay(dbg_account(2));
     let mut state = init_state_with_accounts(vec![
         (dbg_account(1), sender_key_pair.public(), Balance::from(5)),
         (dbg_account(2), dbg_addr(2), Balance::from(0)),
     ]);
-    let transfer_order =
-        init_transfer_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
+    let request_order =
+        init_request_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
     let unknown_key = get_key_pair();
 
-    let unknown_sender_transfer_order = TransferOrder::new(transfer_order.transfer, &unknown_key);
+    let unknown_sender_request_order = RequestOrder::new(request_order.request, &unknown_key);
     assert!(state
-        .handle_transfer_order(unknown_sender_transfer_order)
+        .handle_request_order(unknown_sender_request_order)
         .is_err());
     assert!(state
         .accounts
@@ -75,15 +75,15 @@ fn test_handle_transfer_order_unknown_sender() {
 }
 
 #[test]
-fn test_handle_transfer_order_bad_sequence_number() {
+fn test_handle_request_order_bad_sequence_number() {
     let sender_key_pair = get_key_pair();
     let recipient = Address::FastPay(dbg_account(2));
     let state = init_state_with_accounts(vec![
         (dbg_account(1), sender_key_pair.public(), Balance::from(5)),
         (dbg_account(2), dbg_addr(2), Balance::from(0)),
     ]);
-    let transfer_order =
-        init_transfer_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
+    let request_order =
+        init_request_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
 
     let mut sequence_number_state = state;
     let sequence_number_state_sender_account = sequence_number_state
@@ -96,7 +96,7 @@ fn test_handle_transfer_order_bad_sequence_number() {
             .increment()
             .unwrap();
     assert!(sequence_number_state
-        .handle_transfer_order(transfer_order)
+        .handle_request_order(request_order)
         .is_err());
     assert!(sequence_number_state
         .accounts
@@ -107,20 +107,20 @@ fn test_handle_transfer_order_bad_sequence_number() {
 }
 
 #[test]
-fn test_handle_transfer_order_exceed_balance() {
+fn test_handle_request_order_exceed_balance() {
     let sender_key_pair = get_key_pair();
     let recipient = Address::FastPay(dbg_account(2));
     let mut state = init_state_with_accounts(vec![
         (dbg_account(1), sender_key_pair.public(), Balance::from(5)),
         (dbg_account(2), dbg_addr(2), Balance::from(0)),
     ]);
-    let transfer_order = init_transfer_order(
+    let request_order = init_request_order(
         dbg_account(1),
         &sender_key_pair,
         recipient,
         Amount::from(1000),
     );
-    assert!(state.handle_transfer_order(transfer_order).is_err());
+    assert!(state.handle_request_order(request_order).is_err());
     assert!(state
         .accounts
         .get(&dbg_account(1))
@@ -130,17 +130,17 @@ fn test_handle_transfer_order_exceed_balance() {
 }
 
 #[test]
-fn test_handle_transfer_order_ok() {
+fn test_handle_request_order_ok() {
     let sender_key_pair = get_key_pair();
     let recipient = Address::FastPay(dbg_account(2));
     let mut state = init_state_with_accounts(vec![
         (dbg_account(1), sender_key_pair.public(), Balance::from(5)),
         (dbg_account(2), dbg_addr(2), Balance::from(0)),
     ]);
-    let transfer_order =
-        init_transfer_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
+    let request_order =
+        init_request_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
 
-    let account_info = state.handle_transfer_order(transfer_order).unwrap();
+    let account_info = state.handle_request_order(request_order).unwrap();
     let pending_confirmation = state
         .accounts
         .get(&dbg_account(1))
@@ -155,18 +155,18 @@ fn test_handle_transfer_order_ok() {
 }
 
 #[test]
-fn test_handle_transfer_order_double_spend() {
+fn test_handle_request_order_double_spend() {
     let sender_key_pair = get_key_pair();
     let recipient = Address::FastPay(dbg_account(2));
     let mut state = init_state_with_accounts(vec![
         (dbg_account(1), sender_key_pair.public(), Balance::from(5)),
         (dbg_account(2), dbg_addr(2), Balance::from(0)),
     ]);
-    let transfer_order =
-        init_transfer_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
+    let request_order =
+        init_request_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
 
-    let signed_order = state.handle_transfer_order(transfer_order.clone()).unwrap();
-    let double_spend_signed_order = state.handle_transfer_order(transfer_order).unwrap();
+    let signed_order = state.handle_request_order(request_order.clone()).unwrap();
+    let double_spend_signed_order = state.handle_request_order(request_order).unwrap();
     assert_eq!(signed_order, double_spend_signed_order);
 }
 
@@ -174,7 +174,7 @@ fn test_handle_transfer_order_double_spend() {
 fn test_handle_confirmation_order_unknown_sender() {
     let sender_key_pair = get_key_pair();
     let mut state = init_state_with_accounts(vec![(dbg_account(2), dbg_addr(2), Balance::from(0))]);
-    let certified_transfer_order = init_certified_transfer_order(
+    let certified_request_order = init_certified_request_order(
         dbg_account(1),
         &sender_key_pair,
         Address::FastPay(dbg_account(2)),
@@ -183,7 +183,7 @@ fn test_handle_confirmation_order_unknown_sender() {
     );
 
     assert!(state
-        .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order))
+        .handle_confirmation_order(ConfirmationOrder::new(certified_request_order))
         .is_err());
     assert!(state.accounts.get(&dbg_account(2)).is_some());
     assert!(state.accounts.get(&dbg_account(1)).is_none());
@@ -208,7 +208,7 @@ fn test_handle_confirmation_order_bad_sequence_number() {
         old_seq_num = old_account.next_sequence_number;
     }
 
-    let certified_transfer_order = init_certified_transfer_order(
+    let certified_request_order = init_certified_request_order(
         dbg_account(1),
         &sender_key_pair,
         Address::FastPay(dbg_account(2)),
@@ -217,7 +217,7 @@ fn test_handle_confirmation_order_bad_sequence_number() {
     );
     // Replays are ignored.
     assert!(state
-        .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order))
+        .handle_confirmation_order(ConfirmationOrder::new(certified_request_order))
         .is_ok());
     let new_account = state.accounts.get_mut(&dbg_account(1)).unwrap();
     assert_eq!(old_balance, new_account.balance);
@@ -233,7 +233,7 @@ fn test_handle_confirmation_order_exceed_balance() {
         (dbg_account(2), dbg_addr(2), Balance::from(0)),
     ]);
 
-    let certified_transfer_order = init_certified_transfer_order(
+    let certified_request_order = init_certified_request_order(
         dbg_account(1),
         &sender_key_pair,
         Address::FastPay(dbg_account(2)),
@@ -241,7 +241,7 @@ fn test_handle_confirmation_order_exceed_balance() {
         &state,
     );
     assert!(state
-        .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order))
+        .handle_confirmation_order(ConfirmationOrder::new(certified_request_order))
         .is_ok());
     let new_account = state.accounts.get(&dbg_account(1)).unwrap();
     assert_eq!(Balance::from(-995), new_account.balance);
@@ -258,7 +258,7 @@ fn test_handle_confirmation_order_receiver_balance_overflow() {
         (dbg_account(2), dbg_addr(2), Balance::max()),
     ]);
 
-    let certified_transfer_order = init_certified_transfer_order(
+    let certified_request_order = init_certified_request_order(
         dbg_account(1),
         &sender_key_pair,
         Address::FastPay(dbg_account(2)),
@@ -266,7 +266,7 @@ fn test_handle_confirmation_order_receiver_balance_overflow() {
         &state,
     );
     assert!(state
-        .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order))
+        .handle_confirmation_order(ConfirmationOrder::new(certified_request_order))
         .is_ok());
     let new_sender_account = state.accounts.get(&dbg_account(1)).unwrap();
     assert_eq!(Balance::from(0), new_sender_account.balance);
@@ -285,7 +285,7 @@ fn test_handle_confirmation_order_receiver_equal_sender() {
     let name = key_pair.public();
     let mut state = init_state_with_account(dbg_account(1), name, Balance::from(1));
 
-    let certified_transfer_order = init_certified_transfer_order(
+    let certified_request_order = init_certified_request_order(
         dbg_account(1),
         &key_pair,
         Address::FastPay(dbg_account(1)),
@@ -293,7 +293,7 @@ fn test_handle_confirmation_order_receiver_equal_sender() {
         &state,
     );
     assert!(state
-        .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order))
+        .handle_confirmation_order(ConfirmationOrder::new(certified_request_order))
         .is_ok());
     let account = state.accounts.get(&dbg_account(1)).unwrap();
     assert_eq!(Balance::from(1), account.balance);
@@ -306,7 +306,7 @@ fn test_update_recipient_account() {
     let sender_key_pair = get_key_pair();
     // Sender has no account on this shard.
     let mut state = init_state_with_accounts(vec![(dbg_account(2), dbg_addr(2), Balance::from(1))]);
-    let certified_transfer_order = init_certified_transfer_order(
+    let certified_request_order = init_certified_request_order(
         dbg_account(1),
         &sender_key_pair,
         Address::FastPay(dbg_account(2)),
@@ -314,7 +314,7 @@ fn test_update_recipient_account() {
         &state,
     );
     assert!(state
-        .update_recipient_account(certified_transfer_order)
+        .update_recipient_account(certified_request_order)
         .is_ok());
     let account = state.accounts.get(&dbg_account(2)).unwrap();
     assert_eq!(Balance::from(11), account.balance);
@@ -329,7 +329,7 @@ fn test_handle_confirmation_order_ok() {
         (dbg_account(1), sender_key_pair.public(), Balance::from(5)),
         (dbg_account(2), dbg_addr(2), Balance::from(0)),
     ]);
-    let certified_transfer_order = init_certified_transfer_order(
+    let certified_request_order = init_certified_request_order(
         dbg_account(1),
         &sender_key_pair,
         Address::FastPay(dbg_account(2)),
@@ -343,9 +343,9 @@ fn test_handle_confirmation_order_ok() {
     let mut remaining_balance = old_account.balance;
     remaining_balance = remaining_balance
         .try_sub(
-            certified_transfer_order
+            certified_request_order
                 .value
-                .transfer
+                .request
                 .amount()
                 .unwrap()
                 .into(),
@@ -353,7 +353,7 @@ fn test_handle_confirmation_order_ok() {
         .unwrap();
 
     let (info, _) = state
-        .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order.clone()))
+        .handle_confirmation_order(ConfirmationOrder::new(certified_request_order.clone()))
         .unwrap();
     assert_eq!(dbg_account(1), info.account_id);
     assert_eq!(remaining_balance, info.balance);
@@ -361,31 +361,31 @@ fn test_handle_confirmation_order_ok() {
     assert_eq!(None, info.pending_confirmation);
     assert_eq!(
         state.accounts.get(&dbg_account(1)).unwrap().confirmed_log,
-        vec![certified_transfer_order.clone()]
+        vec![certified_request_order.clone()]
     );
 
     let recipient_account = state.accounts.get(&dbg_account(2)).unwrap();
     assert_eq!(
         recipient_account.balance,
-        certified_transfer_order
+        certified_request_order
             .value
-            .transfer
+            .request
             .amount()
             .unwrap()
             .into()
     );
 
-    let info_request = AccountInfoRequest {
+    let info_query = AccountInfoQuery {
         account_id: dbg_account(2),
-        request_sequence_number: None,
-        request_received_transfers_excluding_first_nth: Some(0),
+        query_sequence_number: None,
+        query_received_requests_excluding_first_nth: Some(0),
     };
-    let response = state.handle_account_info_request(info_request).unwrap();
-    assert_eq!(response.requested_received_transfers.len(), 1);
+    let response = state.handle_account_info_query(info_query).unwrap();
+    assert_eq!(response.queried_received_requests.len(), 1);
     assert_eq!(
-        response.requested_received_transfers[0]
+        response.queried_received_requests[0]
             .value
-            .transfer
+            .request
             .amount()
             .unwrap(),
         Amount::from(5)
@@ -500,13 +500,13 @@ fn init_state_with_account(id: AccountId, owner: AccountOwner, balance: Balance)
 }
 
 #[cfg(test)]
-fn init_transfer_order(
+fn init_request_order(
     account_id: AccountId,
     secret: &KeyPair,
     recipient: Address,
     amount: Amount,
-) -> TransferOrder {
-    let transfer = Transfer {
+) -> RequestOrder {
+    let request = Request {
         account_id,
         operation: Operation::Payment {
             recipient,
@@ -515,20 +515,20 @@ fn init_transfer_order(
         },
         sequence_number: SequenceNumber::new(),
     };
-    TransferOrder::new(transfer, secret)
+    RequestOrder::new(request, secret)
 }
 
 #[cfg(test)]
-fn init_certified_transfer_order(
+fn init_certified_request_order(
     account_id: AccountId,
     key_pair: &KeyPair,
     recipient: Address,
     amount: Amount,
     state: &AuthorityState,
-) -> CertifiedTransferOrder {
-    let transfer_order = init_transfer_order(account_id, key_pair, recipient, amount);
-    let vote = SignedTransferOrder::new(transfer_order.clone(), &state.key_pair);
-    let mut builder = SignatureAggregator::try_new(transfer_order, &state.committee).unwrap();
+) -> CertifiedRequestOrder {
+    let request_order = init_request_order(account_id, key_pair, recipient, amount);
+    let vote = SignedRequestOrder::new(request_order.clone(), &state.key_pair);
+    let mut builder = SignatureAggregator::try_new(request_order, &state.committee).unwrap();
     builder
         .append(vote.authority, vote.signature)
         .unwrap()

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -62,7 +62,8 @@ fn test_handle_request_order_unknown_sender() {
         init_request_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
     let unknown_key = get_key_pair();
 
-    let unknown_sender_request_order = RequestOrder::new(request_order.request, &unknown_key);
+    let unknown_sender_request_order =
+        RequestOrder::new(request_order.request, &unknown_key, Vec::new());
     assert!(state
         .handle_request_order(unknown_sender_request_order)
         .is_err());
@@ -513,7 +514,7 @@ fn init_request_order(
         },
         sequence_number: SequenceNumber::new(),
     };
-    RequestOrder::new(request, secret)
+    RequestOrder::new(request, secret, Vec::new())
 }
 
 #[cfg(test)]

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -24,7 +24,7 @@ fn test_handle_request_order_bad_signature() {
         .accounts
         .get(&dbg_account(1))
         .unwrap()
-        .pending_confirmation
+        .pending
         .is_none());
 }
 
@@ -46,7 +46,7 @@ fn test_handle_request_order_zero_amount() {
         .accounts
         .get(&dbg_account(1))
         .unwrap()
-        .pending_confirmation
+        .pending
         .is_none());
 }
 
@@ -70,7 +70,7 @@ fn test_handle_request_order_unknown_sender() {
         .accounts
         .get(&dbg_account(1))
         .unwrap()
-        .pending_confirmation
+        .pending
         .is_none());
 }
 
@@ -102,7 +102,7 @@ fn test_handle_request_order_bad_sequence_number() {
         .accounts
         .get(&dbg_account(1))
         .unwrap()
-        .pending_confirmation
+        .pending
         .is_none());
 }
 
@@ -125,7 +125,7 @@ fn test_handle_request_order_exceed_balance() {
         .accounts
         .get(&dbg_account(1))
         .unwrap()
-        .pending_confirmation
+        .pending
         .is_none());
 }
 
@@ -141,17 +141,14 @@ fn test_handle_request_order_ok() {
         init_request_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
 
     let account_info = state.handle_request_order(request_order).unwrap();
-    let pending_confirmation = state
+    let pending = state
         .accounts
         .get(&dbg_account(1))
         .unwrap()
-        .pending_confirmation
+        .pending
         .clone()
         .unwrap();
-    assert_eq!(
-        account_info.pending_confirmation.unwrap(),
-        pending_confirmation
-    );
+    assert_eq!(account_info.pending.unwrap(), pending);
 }
 
 #[test]
@@ -165,9 +162,9 @@ fn test_handle_request_order_double_spend() {
     let request_order =
         init_request_order(dbg_account(1), &sender_key_pair, recipient, Amount::from(5));
 
-    let signed_order = state.handle_request_order(request_order.clone()).unwrap();
-    let double_spend_signed_order = state.handle_request_order(request_order).unwrap();
-    assert_eq!(signed_order, double_spend_signed_order);
+    let vote = state.handle_request_order(request_order.clone()).unwrap();
+    let double_spend_vote = state.handle_request_order(request_order).unwrap();
+    assert_eq!(vote, double_spend_vote);
 }
 
 #[test]
@@ -357,7 +354,7 @@ fn test_handle_confirmation_order_ok() {
     assert_eq!(dbg_account(1), info.account_id);
     assert_eq!(remaining_balance, info.balance);
     assert_eq!(next_sequence_number, info.next_sequence_number);
-    assert_eq!(None, info.pending_confirmation);
+    assert_eq!(None, info.pending);
     assert_eq!(
         state.accounts.get(&dbg_account(1)).unwrap().confirmed_log,
         vec![certificate.clone()]

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -495,7 +495,7 @@ fn init_request_order(
 ) -> RequestOrder {
     let request = Request {
         account_id,
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient,
             amount,
             user_data: UserData::default(),

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -342,14 +342,7 @@ fn test_handle_confirmation_order_ok() {
     next_sequence_number = next_sequence_number.increment().unwrap();
     let mut remaining_balance = old_account.balance;
     remaining_balance = remaining_balance
-        .try_sub(
-            certified_request_order
-                .value
-                .request
-                .amount()
-                .unwrap()
-                .into(),
-        )
+        .try_sub(certified_request_order.value.amount().unwrap().into())
         .unwrap();
 
     let (info, _) = state
@@ -367,12 +360,7 @@ fn test_handle_confirmation_order_ok() {
     let recipient_account = state.accounts.get(&dbg_account(2)).unwrap();
     assert_eq!(
         recipient_account.balance,
-        certified_request_order
-            .value
-            .request
-            .amount()
-            .unwrap()
-            .into()
+        certified_request_order.value.amount().unwrap().into()
     );
 
     let info_query = AccountInfoQuery {
@@ -385,7 +373,6 @@ fn test_handle_confirmation_order_ok() {
     assert_eq!(
         response.queried_received_requests[0]
             .value
-            .request
             .amount()
             .unwrap(),
         Amount::from(5)
@@ -525,10 +512,10 @@ fn init_certified_request_order(
     recipient: Address,
     amount: Amount,
     state: &AuthorityState,
-) -> CertifiedRequestOrder {
-    let request_order = init_request_order(account_id, key_pair, recipient, amount);
-    let vote = SignedRequestOrder::new(request_order.clone(), &state.key_pair);
-    let mut builder = SignatureAggregator::try_new(request_order, &state.committee).unwrap();
+) -> CertifiedRequest {
+    let request = init_request_order(account_id, key_pair, recipient, amount).request;
+    let vote = SignedRequest::new(request.clone(), &state.key_pair);
+    let mut builder = SignatureAggregator::new(request, &state.committee);
     builder
         .append(vote.authority, vote.signature)
         .unwrap()

--- a/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
+++ b/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
@@ -144,7 +144,7 @@ fn init_funding_transaction() -> FundingTransaction {
 fn init_redeem_transaction(committee: Committee, secret: KeyPair) -> RedeemTransaction {
     let request = Request {
         account_id: dbg_account(1),
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient: Address::Primary(dbg_addr(2)),
             amount: Amount::from(3),
             user_data: UserData::default(),

--- a/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
+++ b/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
@@ -58,22 +58,22 @@ fn test_handle_redeem_transaction_ok() {
         .handle_redeem_transaction(redeem_transaction.clone())
         .is_ok());
     let account_id = redeem_transaction
-        .transfer_certificate
+        .request_certificate
         .value
-        .transfer
+        .request
         .account_id
         .clone();
     let amount = redeem_transaction
-        .transfer_certificate
+        .request_certificate
         .value
-        .transfer
+        .request
         .amount()
         .unwrap();
     let account = contract_state.accounts.get(&account_id).unwrap();
     let sequence_number = redeem_transaction
-        .transfer_certificate
+        .request_certificate
         .value
-        .transfer
+        .request
         .sequence_number;
     assert_eq!(account.last_redeemed, Some(sequence_number));
     old_total_balance = old_total_balance.try_sub(amount).unwrap();
@@ -92,14 +92,14 @@ fn test_handle_redeem_transaction_negative_balance() {
     let old_balance = contract_state.total_balance;
 
     *redeem_transaction
-        .transfer_certificate
+        .request_certificate
         .value
-        .transfer
+        .request
         .amount_mut()
         .unwrap() = redeem_transaction
-        .transfer_certificate
+        .request_certificate
         .value
-        .transfer
+        .request
         .amount_mut()
         .unwrap()
         .try_add(too_much_money)
@@ -151,7 +151,7 @@ fn init_funding_transaction() -> FundingTransaction {
 #[cfg(test)]
 fn init_redeem_transaction(committee: Committee, secret: KeyPair) -> RedeemTransaction {
     let sender_key = get_key_pair();
-    let primary_transfer = Transfer {
+    let primary_request = Request {
         account_id: dbg_account(1),
         operation: Operation::Payment {
             recipient: Address::Primary(dbg_addr(2)),
@@ -160,14 +160,14 @@ fn init_redeem_transaction(committee: Committee, secret: KeyPair) -> RedeemTrans
         },
         sequence_number: SequenceNumber::new(),
     };
-    let order = TransferOrder::new(primary_transfer, &sender_key);
-    let vote = SignedTransferOrder::new(order.clone(), &secret);
+    let order = RequestOrder::new(primary_request, &sender_key);
+    let vote = SignedRequestOrder::new(order.clone(), &secret);
     let mut builder = SignatureAggregator::try_new(order, &committee).unwrap();
     let certificate = builder
         .append(vote.authority, vote.signature)
         .unwrap()
         .unwrap();
     RedeemTransaction {
-        transfer_certificate: certificate,
+        request_certificate: certificate,
     }
 }

--- a/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
+++ b/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
@@ -60,21 +60,15 @@ fn test_handle_redeem_transaction_ok() {
     let account_id = redeem_transaction
         .request_certificate
         .value
-        .request
         .account_id
         .clone();
     let amount = redeem_transaction
         .request_certificate
         .value
-        .request
         .amount()
         .unwrap();
     let account = contract_state.accounts.get(&account_id).unwrap();
-    let sequence_number = redeem_transaction
-        .request_certificate
-        .value
-        .request
-        .sequence_number;
+    let sequence_number = redeem_transaction.request_certificate.value.sequence_number;
     assert_eq!(account.last_redeemed, Some(sequence_number));
     old_total_balance = old_total_balance.try_sub(amount).unwrap();
     assert_eq!(contract_state.total_balance, old_total_balance);
@@ -94,12 +88,10 @@ fn test_handle_redeem_transaction_negative_balance() {
     *redeem_transaction
         .request_certificate
         .value
-        .request
         .amount_mut()
         .unwrap() = redeem_transaction
         .request_certificate
         .value
-        .request
         .amount_mut()
         .unwrap()
         .try_add(too_much_money)
@@ -150,8 +142,7 @@ fn init_funding_transaction() -> FundingTransaction {
 
 #[cfg(test)]
 fn init_redeem_transaction(committee: Committee, secret: KeyPair) -> RedeemTransaction {
-    let sender_key = get_key_pair();
-    let primary_request = Request {
+    let request = Request {
         account_id: dbg_account(1),
         operation: Operation::Payment {
             recipient: Address::Primary(dbg_addr(2)),
@@ -160,9 +151,8 @@ fn init_redeem_transaction(committee: Committee, secret: KeyPair) -> RedeemTrans
         },
         sequence_number: SequenceNumber::new(),
     };
-    let order = RequestOrder::new(primary_request, &sender_key);
-    let vote = SignedRequestOrder::new(order.clone(), &secret);
-    let mut builder = SignatureAggregator::try_new(order, &committee).unwrap();
+    let vote = SignedRequest::new(request.clone(), &secret);
+    let mut builder = SignatureAggregator::new(request, &committee);
     let certificate = builder
         .append(vote.authority, vote.signature)
         .unwrap()

--- a/fastpay_core/src/unit_tests/messages_tests.rs
+++ b/fastpay_core/src/unit_tests/messages_tests.rs
@@ -26,14 +26,15 @@ fn test_signed_values() {
         },
         sequence_number: SequenceNumber::new(),
     };
+    let value = Value::Confirm(request);
 
-    let v = SignedRequest::new(request.clone(), &key1);
+    let v = Vote::new(value.clone(), &key1);
     assert!(v.check(&committee).is_ok());
 
-    let v = SignedRequest::new(request.clone(), &key2);
+    let v = Vote::new(value.clone(), &key2);
     assert!(v.check(&committee).is_err());
 
-    let v = SignedRequest::new(request, &key3);
+    let v = Vote::new(value, &key3);
     assert!(v.check(&committee).is_err());
 }
 
@@ -59,12 +60,13 @@ fn test_certificates() {
         },
         sequence_number: SequenceNumber::new(),
     };
+    let value = Value::Confirm(request);
 
-    let v1 = SignedRequest::new(request.clone(), &key1);
-    let v2 = SignedRequest::new(request.clone(), &key2);
-    let v3 = SignedRequest::new(request.clone(), &key3);
+    let v1 = Vote::new(value.clone(), &key1);
+    let v2 = Vote::new(value.clone(), &key2);
+    let v3 = Vote::new(value.clone(), &key3);
 
-    let mut builder = SignatureAggregator::new(request.clone(), &committee);
+    let mut builder = SignatureAggregator::new(value.clone(), &committee);
     assert!(builder
         .append(v1.authority, v1.signature)
         .unwrap()
@@ -74,7 +76,7 @@ fn test_certificates() {
     c.signatures.pop();
     assert!(c.check(&committee).is_err());
 
-    let mut builder = SignatureAggregator::new(request, &committee);
+    let mut builder = SignatureAggregator::new(value, &committee);
     assert!(builder
         .append(v1.authority, v1.signature)
         .unwrap()

--- a/fastpay_core/src/unit_tests/messages_tests.rs
+++ b/fastpay_core/src/unit_tests/messages_tests.rs
@@ -17,7 +17,7 @@ fn test_signed_values() {
     authorities.insert(name2, /* voting right */ 0);
     let committee = Committee::new(authorities);
 
-    let transfer = Transfer {
+    let request = Request {
         account_id: dbg_account(1),
         operation: Operation::Payment {
             recipient: Address::FastPay(dbg_account(2)),
@@ -26,20 +26,20 @@ fn test_signed_values() {
         },
         sequence_number: SequenceNumber::new(),
     };
-    let order = TransferOrder::new(transfer.clone(), &key1);
-    let mut bad_order = TransferOrder::new(transfer, &key2);
+    let order = RequestOrder::new(request.clone(), &key1);
+    let mut bad_order = RequestOrder::new(request, &key2);
     bad_order.owner = name1;
 
-    let v = SignedTransferOrder::new(order.clone(), &key1);
+    let v = SignedRequestOrder::new(order.clone(), &key1);
     assert!(v.check(&committee).is_ok());
 
-    let v = SignedTransferOrder::new(order.clone(), &key2);
+    let v = SignedRequestOrder::new(order.clone(), &key2);
     assert!(v.check(&committee).is_err());
 
-    let v = SignedTransferOrder::new(order, &key3);
+    let v = SignedRequestOrder::new(order, &key3);
     assert!(v.check(&committee).is_err());
 
-    let v = SignedTransferOrder::new(bad_order, &key1);
+    let v = SignedRequestOrder::new(bad_order, &key1);
     assert!(v.check(&committee).is_err());
 }
 
@@ -56,7 +56,7 @@ fn test_certificates() {
     authorities.insert(name2, /* voting right */ 1);
     let committee = Committee::new(authorities);
 
-    let transfer = Transfer {
+    let request = Request {
         account_id: dbg_account(1),
         operation: Operation::Payment {
             recipient: Address::FastPay(dbg_account(1)),
@@ -65,13 +65,13 @@ fn test_certificates() {
         },
         sequence_number: SequenceNumber::new(),
     };
-    let order = TransferOrder::new(transfer.clone(), &key1);
-    let mut bad_order = TransferOrder::new(transfer, &key2);
+    let order = RequestOrder::new(request.clone(), &key1);
+    let mut bad_order = RequestOrder::new(request, &key2);
     bad_order.owner = name1;
 
-    let v1 = SignedTransferOrder::new(order.clone(), &key1);
-    let v2 = SignedTransferOrder::new(order.clone(), &key2);
-    let v3 = SignedTransferOrder::new(order.clone(), &key3);
+    let v1 = SignedRequestOrder::new(order.clone(), &key1);
+    let v2 = SignedRequestOrder::new(order.clone(), &key2);
+    let v3 = SignedRequestOrder::new(order.clone(), &key3);
 
     let mut builder = SignatureAggregator::try_new(order.clone(), &committee).unwrap();
     assert!(builder

--- a/fastpay_core/src/unit_tests/messages_tests.rs
+++ b/fastpay_core/src/unit_tests/messages_tests.rs
@@ -26,20 +26,14 @@ fn test_signed_values() {
         },
         sequence_number: SequenceNumber::new(),
     };
-    let order = RequestOrder::new(request.clone(), &key1);
-    let mut bad_order = RequestOrder::new(request, &key2);
-    bad_order.owner = name1;
 
-    let v = SignedRequestOrder::new(order.clone(), &key1);
+    let v = SignedRequest::new(request.clone(), &key1);
     assert!(v.check(&committee).is_ok());
 
-    let v = SignedRequestOrder::new(order.clone(), &key2);
+    let v = SignedRequest::new(request.clone(), &key2);
     assert!(v.check(&committee).is_err());
 
-    let v = SignedRequestOrder::new(order, &key3);
-    assert!(v.check(&committee).is_err());
-
-    let v = SignedRequestOrder::new(bad_order, &key1);
+    let v = SignedRequest::new(request, &key3);
     assert!(v.check(&committee).is_err());
 }
 
@@ -65,15 +59,12 @@ fn test_certificates() {
         },
         sequence_number: SequenceNumber::new(),
     };
-    let order = RequestOrder::new(request.clone(), &key1);
-    let mut bad_order = RequestOrder::new(request, &key2);
-    bad_order.owner = name1;
 
-    let v1 = SignedRequestOrder::new(order.clone(), &key1);
-    let v2 = SignedRequestOrder::new(order.clone(), &key2);
-    let v3 = SignedRequestOrder::new(order.clone(), &key3);
+    let v1 = SignedRequest::new(request.clone(), &key1);
+    let v2 = SignedRequest::new(request.clone(), &key2);
+    let v3 = SignedRequest::new(request.clone(), &key3);
 
-    let mut builder = SignatureAggregator::try_new(order.clone(), &committee).unwrap();
+    let mut builder = SignatureAggregator::new(request.clone(), &committee);
     assert!(builder
         .append(v1.authority, v1.signature)
         .unwrap()
@@ -83,12 +74,10 @@ fn test_certificates() {
     c.signatures.pop();
     assert!(c.check(&committee).is_err());
 
-    let mut builder = SignatureAggregator::try_new(order, &committee).unwrap();
+    let mut builder = SignatureAggregator::new(request, &committee);
     assert!(builder
         .append(v1.authority, v1.signature)
         .unwrap()
         .is_none());
     assert!(builder.append(v3.authority, v3.signature).is_err());
-
-    assert!(SignatureAggregator::try_new(bad_order, &committee).is_err());
 }

--- a/fastpay_core/src/unit_tests/messages_tests.rs
+++ b/fastpay_core/src/unit_tests/messages_tests.rs
@@ -19,7 +19,7 @@ fn test_signed_values() {
 
     let request = Request {
         account_id: dbg_account(1),
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient: Address::FastPay(dbg_account(2)),
             amount: Amount::from(1),
             user_data: UserData::default(),
@@ -52,7 +52,7 @@ fn test_certificates() {
 
     let request = Request {
         account_id: dbg_account(1),
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient: Address::FastPay(dbg_account(1)),
             amount: Amount::from(1),
             user_data: UserData::default(),

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -188,7 +188,7 @@ fn test_info_response() {
         owner: Some(sender_key.public()),
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
-        pending_confirmation: None,
+        pending: None,
         queried_certificate: None,
         queried_received_requests: Vec::new(),
     };
@@ -197,7 +197,7 @@ fn test_info_response() {
         owner: None,
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
-        pending_confirmation: Some(vote.clone()),
+        pending: Some(vote.clone()),
         queried_certificate: None,
         queried_received_requests: Vec::new(),
     };
@@ -206,7 +206,7 @@ fn test_info_response() {
         owner: None,
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
-        pending_confirmation: None,
+        pending: None,
         queried_certificate: Some(cert.clone()),
         queried_received_requests: Vec::new(),
     };
@@ -215,7 +215,7 @@ fn test_info_response() {
         owner: None,
         balance: Balance::from(50),
         next_sequence_number: SequenceNumber::new(),
-        pending_confirmation: Some(vote),
+        pending: Some(vote),
         queried_certificate: Some(cert),
         queried_received_requests: Vec::new(),
     };

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -254,9 +254,10 @@ fn test_time_order() {
 
     let mut buf2 = buf.as_slice();
     let now = Instant::now();
+    let owner = Some(sender_key.public());
     for _ in 0..100 {
         if let SerializedMessage::Order(order) = deserialize_message(&mut buf2).unwrap() {
-            order.check_signature().unwrap();
+            order.check(&owner).unwrap();
         }
     }
     assert!(deserialize_message(&mut buf2).is_err());

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -70,7 +70,7 @@ fn test_order() {
     let buf = serialize_request_order(&request_order);
     let result = deserialize_message(buf.as_slice());
     assert!(result.is_ok());
-    if let SerializedMessage::Order(o) = result.unwrap() {
+    if let SerializedMessage::RequestOrder(o) = result.unwrap() {
         assert!(*o == request_order);
     } else {
         panic!()
@@ -91,7 +91,7 @@ fn test_order() {
     let buf = serialize_request_order(&request_order2);
     let result = deserialize_message(buf.as_slice());
     assert!(result.is_ok());
-    if let SerializedMessage::Order(o) = result.unwrap() {
+    if let SerializedMessage::RequestOrder(o) = result.unwrap() {
         assert!(*o == request_order2);
     } else {
         panic!()
@@ -257,7 +257,7 @@ fn test_time_order() {
     let now = Instant::now();
     let owner = Some(sender_key.public());
     for _ in 0..100 {
-        if let SerializedMessage::Order(order) = deserialize_message(&mut buf2).unwrap() {
+        if let SerializedMessage::RequestOrder(order) = deserialize_message(&mut buf2).unwrap() {
             order.check(&owner).unwrap();
         }
     }

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -65,7 +65,7 @@ fn test_order() {
         },
         sequence_number: SequenceNumber::new(),
     };
-    let request_order = RequestOrder::new(request, &sender_key);
+    let request_order = RequestOrder::new(request, &sender_key, Vec::new());
 
     let buf = serialize_request_order(&request_order);
     let result = deserialize_message(buf.as_slice());
@@ -86,7 +86,7 @@ fn test_order() {
         },
         sequence_number: SequenceNumber::new(),
     };
-    let request_order2 = RequestOrder::new(request2, &sender_key);
+    let request_order2 = RequestOrder::new(request2, &sender_key, Vec::new());
 
     let buf = serialize_request_order(&request_order2);
     let result = deserialize_message(buf.as_slice());
@@ -248,7 +248,7 @@ fn test_time_order() {
     let mut buf = Vec::new();
     let now = Instant::now();
     for _ in 0..100 {
-        let request_order = RequestOrder::new(request.clone(), &sender_key);
+        let request_order = RequestOrder::new(request.clone(), &sender_key, Vec::new());
         serialize_request_order_into(&mut buf, &request_order).unwrap();
     }
     println!("Write Order: {} microsec", now.elapsed().as_micros() / 100);

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -58,7 +58,7 @@ fn test_order() {
 
     let request = Request {
         account_id: dbg_account(1),
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient: Address::FastPay(dbg_account(0x20)),
             amount: Amount::from(5),
             user_data: UserData::default(),
@@ -79,7 +79,7 @@ fn test_order() {
     let sender_key = get_key_pair();
     let request2 = Request {
         account_id: dbg_account(1),
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient: Address::FastPay(dbg_account(0x20)),
             amount: Amount::from(5),
             user_data: UserData::default(),
@@ -102,7 +102,7 @@ fn test_order() {
 fn test_vote() {
     let request = Request {
         account_id: dbg_account(1),
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient: Address::Primary(dbg_addr(0x20)),
             amount: Amount::from(5),
             user_data: UserData::default(),
@@ -126,7 +126,7 @@ fn test_vote() {
 fn test_cert() {
     let request = Request {
         account_id: dbg_account(1),
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient: Address::Primary(dbg_addr(0x20)),
             amount: Amount::from(5),
             user_data: UserData::default(),
@@ -160,7 +160,7 @@ fn test_info_response() {
     let sender_key = get_key_pair();
     let request = Request {
         account_id: dbg_account(1),
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient: Address::Primary(dbg_addr(0x20)),
             amount: Amount::from(5),
             user_data: UserData::default(),
@@ -236,7 +236,7 @@ fn test_time_order() {
     let sender_key = get_key_pair();
     let request = Request {
         account_id: dbg_account(1),
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient: Address::Primary(dbg_addr(0x20)),
             amount: Amount::from(5),
             user_data: UserData::default(),
@@ -270,7 +270,7 @@ fn test_time_order() {
 fn test_time_vote() {
     let request = Request {
         account_id: dbg_account(1),
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient: Address::Primary(dbg_addr(0x20)),
             amount: Amount::from(5),
             user_data: UserData::default(),
@@ -307,7 +307,7 @@ fn test_time_cert() {
     let count = 100;
     let request = Request {
         account_id: dbg_account(1),
-        operation: Operation::Payment {
+        operation: Operation::Transfer {
             recipient: Address::Primary(dbg_addr(0)),
             amount: Amount::from(5),
             user_data: UserData::default(),

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -25,13 +25,13 @@ AccountInfoResponse:
         TYPENAME: SequenceNumber
     - pending_confirmation:
         OPTION:
-          TYPENAME: SignedRequest
+          TYPENAME: Vote
     - queried_certificate:
         OPTION:
-          TYPENAME: CertifiedRequest
+          TYPENAME: Certificate
     - queried_received_requests:
         SEQ:
-          TYPENAME: CertifiedRequest
+          TYPENAME: Certificate
 Address:
   ENUM:
     0:
@@ -46,10 +46,10 @@ Amount:
   NEWTYPESTRUCT: U64
 Balance:
   NEWTYPESTRUCT: I128
-CertifiedRequest:
+Certificate:
   STRUCT:
     - value:
-        TYPENAME: Request
+        TYPENAME: Value
     - signatures:
         SEQ:
           TUPLE:
@@ -66,7 +66,7 @@ ConfirmationOutcome:
 CrossShardRequest:
   STRUCT:
     - certificate:
-        TYPENAME: CertifiedRequest
+        TYPENAME: Certificate
 FastPayError:
   ENUM:
     0:
@@ -98,7 +98,7 @@ FastPayError:
       PreviousRequestMustBeConfirmedFirst:
         STRUCT:
           - pending_confirmation:
-              TYPENAME: Request
+              TYPENAME: Value
     10:
       ErrorWhileProcessingRequestOrder: UNIT
     11:
@@ -141,6 +141,8 @@ FastPayError:
     27:
       UnexpectedMessage: UNIT
     28:
+      InvalidConfirmationOrder: UNIT
+    29:
       ClientIoError:
         STRUCT:
           - error: STR
@@ -201,11 +203,11 @@ SerializedMessage:
     1:
       Vote:
         NEWTYPE:
-          TYPENAME: SignedRequest
+          TYPENAME: Vote
     2:
-      Confirmation:
+      Certificate:
         NEWTYPE:
-          TYPENAME: CertifiedRequest
+          TYPENAME: Certificate
     3:
       Error:
         NEWTYPE:
@@ -227,18 +229,28 @@ Signature:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 64
-SignedRequest:
-  STRUCT:
-    - value:
-        TYPENAME: Request
-    - authority:
-        TYPENAME: PublicKeyBytes
-    - signature:
-        TYPENAME: Signature
 UserData:
   NEWTYPESTRUCT:
     OPTION:
       TUPLEARRAY:
         CONTENT: U8
         SIZE: 32
+Value:
+  ENUM:
+    0:
+      Lock:
+        NEWTYPE:
+          TYPENAME: Request
+    1:
+      Confirm:
+        NEWTYPE:
+          TYPENAME: Request
+Vote:
+  STRUCT:
+    - value:
+        TYPENAME: Value
+    - authority:
+        TYPENAME: PublicKeyBytes
+    - signature:
+        TYPENAME: Signature
 

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -147,7 +147,7 @@ FastPayError:
 Operation:
   ENUM:
     0:
-      Payment:
+      Transfer:
         STRUCT:
           - recipient:
               TYPENAME: Address

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -23,7 +23,7 @@ AccountInfoResponse:
         TYPENAME: Balance
     - next_sequence_number:
         TYPENAME: SequenceNumber
-    - pending_confirmation:
+    - pending:
         OPTION:
           TYPENAME: Vote
     - queried_certificate:
@@ -97,7 +97,7 @@ FastPayError:
     9:
       PreviousRequestMustBeConfirmedFirst:
         STRUCT:
-          - pending_confirmation:
+          - pending:
               TYPENAME: Value
     10:
       ErrorWhileProcessingRequestOrder: UNIT

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -3,14 +3,14 @@ AccountId:
   NEWTYPESTRUCT:
     SEQ:
       TYPENAME: SequenceNumber
-AccountInfoRequest:
+AccountInfoQuery:
   STRUCT:
     - account_id:
         TYPENAME: AccountId
-    - request_sequence_number:
+    - query_sequence_number:
         OPTION:
           TYPENAME: SequenceNumber
-    - request_received_transfers_excluding_first_nth:
+    - query_received_requests_excluding_first_nth:
         OPTION: U64
 AccountInfoResponse:
   STRUCT:
@@ -25,13 +25,13 @@ AccountInfoResponse:
         TYPENAME: SequenceNumber
     - pending_confirmation:
         OPTION:
-          TYPENAME: SignedTransferOrder
-    - requested_certificate:
+          TYPENAME: SignedRequestOrder
+    - queried_certificate:
         OPTION:
-          TYPENAME: CertifiedTransferOrder
-    - requested_received_transfers:
+          TYPENAME: CertifiedRequestOrder
+    - queried_received_requests:
         SEQ:
-          TYPENAME: CertifiedTransferOrder
+          TYPENAME: CertifiedRequestOrder
 Address:
   ENUM:
     0:
@@ -46,10 +46,10 @@ Amount:
   NEWTYPESTRUCT: U64
 Balance:
   NEWTYPESTRUCT: I128
-CertifiedTransferOrder:
+CertifiedRequestOrder:
   STRUCT:
     - value:
-        TYPENAME: TransferOrder
+        TYPENAME: RequestOrder
     - signatures:
         SEQ:
           TUPLE:
@@ -66,7 +66,7 @@ ConfirmationOutcome:
 CrossShardRequest:
   STRUCT:
     - certificate:
-        TYPENAME: CertifiedTransferOrder
+        TYPENAME: CertifiedRequestOrder
 FastPayError:
   ENUM:
     0:
@@ -95,12 +95,12 @@ FastPayError:
         NEWTYPE:
           TYPENAME: AccountId
     9:
-      PreviousTransferMustBeConfirmedFirst:
+      PreviousRequestMustBeConfirmedFirst:
         STRUCT:
           - pending_confirmation:
-              TYPENAME: TransferOrder
+              TYPENAME: RequestOrder
     10:
-      ErrorWhileProcessingTransferOrder: UNIT
+      ErrorWhileProcessingRequestOrder: UNIT
     11:
       ErrorWhileRequestingCertificate: UNIT
     12:
@@ -156,7 +156,7 @@ Operation:
           - user_data:
               TYPENAME: UserData
     1:
-      CreateAccount:
+      OpenAccount:
         STRUCT:
           - new_id:
               TYPENAME: AccountId
@@ -174,6 +174,22 @@ PublicKeyBytes:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 32
+Request:
+  STRUCT:
+    - account_id:
+        TYPENAME: AccountId
+    - operation:
+        TYPENAME: Operation
+    - sequence_number:
+        TYPENAME: SequenceNumber
+RequestOrder:
+  STRUCT:
+    - request:
+        TYPENAME: Request
+    - owner:
+        TYPENAME: PublicKeyBytes
+    - signature:
+        TYPENAME: Signature
 SequenceNumber:
   NEWTYPESTRUCT: U64
 SerializedMessage:
@@ -181,23 +197,23 @@ SerializedMessage:
     0:
       Order:
         NEWTYPE:
-          TYPENAME: TransferOrder
+          TYPENAME: RequestOrder
     1:
       Vote:
         NEWTYPE:
-          TYPENAME: SignedTransferOrder
+          TYPENAME: SignedRequestOrder
     2:
       Confirmation:
         NEWTYPE:
-          TYPENAME: CertifiedTransferOrder
+          TYPENAME: CertifiedRequestOrder
     3:
       Error:
         NEWTYPE:
           TYPENAME: FastPayError
     4:
-      InfoRequest:
+      InfoQuery:
         NEWTYPE:
-          TYPENAME: AccountInfoRequest
+          TYPENAME: AccountInfoQuery
     5:
       InfoResponse:
         NEWTYPE:
@@ -211,27 +227,11 @@ Signature:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 64
-SignedTransferOrder:
+SignedRequestOrder:
   STRUCT:
     - value:
-        TYPENAME: TransferOrder
+        TYPENAME: RequestOrder
     - authority:
-        TYPENAME: PublicKeyBytes
-    - signature:
-        TYPENAME: Signature
-Transfer:
-  STRUCT:
-    - account_id:
-        TYPENAME: AccountId
-    - operation:
-        TYPENAME: Operation
-    - sequence_number:
-        TYPENAME: SequenceNumber
-TransferOrder:
-  STRUCT:
-    - transfer:
-        TYPENAME: Transfer
-    - owner:
         TYPENAME: PublicKeyBytes
     - signature:
         TYPENAME: Signature

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -55,6 +55,37 @@ Certificate:
           TUPLE:
             - TYPENAME: PublicKeyBytes
             - TYPENAME: Signature
+Coin:
+  STRUCT:
+    - account_id:
+        TYPENAME: AccountId
+    - amount:
+        TYPENAME: Amount
+CoinCreationContract:
+  STRUCT:
+    - seed: U128
+    - sources:
+        SEQ:
+          TYPENAME: CoinCreationSource
+    - targets:
+        SEQ:
+          TYPENAME: Coin
+CoinCreationOrder:
+  STRUCT:
+    - contract:
+        TYPENAME: CoinCreationContract
+    - locks:
+        SEQ:
+          TYPENAME: Certificate
+CoinCreationSource:
+  STRUCT:
+    - account_id:
+        TYPENAME: AccountId
+    - amount:
+        TYPENAME: Amount
+    - coins:
+        SEQ:
+          TYPENAME: Certificate
 ConfirmationOutcome:
   ENUM:
     0:
@@ -64,9 +95,17 @@ ConfirmationOutcome:
     2:
       Cancel: UNIT
 CrossShardRequest:
-  STRUCT:
-    - certificate:
-        TYPENAME: Certificate
+  ENUM:
+    0:
+      UpdateRecipient:
+        STRUCT:
+          - certificate:
+              TYPENAME: Certificate
+    1:
+      DestroyAccount:
+        STRUCT:
+          - account_id:
+              TYPENAME: AccountId
 FastPayError:
   ENUM:
     0:
@@ -143,9 +182,16 @@ FastPayError:
     28:
       InvalidConfirmationOrder: UNIT
     29:
+      InvalidCoinCreationOrder: UNIT
+    30:
       ClientIoError:
         STRUCT:
           - error: STR
+HashValue:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 64
 Operation:
   ENUM:
     0:
@@ -171,6 +217,13 @@ Operation:
         STRUCT:
           - new_owner:
               TYPENAME: PublicKeyBytes
+    4:
+      Spend:
+        STRUCT:
+          - account_balance:
+              TYPENAME: Amount
+          - contract_hash:
+              TYPENAME: HashValue
 PublicKeyBytes:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -197,7 +250,7 @@ SequenceNumber:
 SerializedMessage:
   ENUM:
     0:
-      Order:
+      RequestOrder:
         NEWTYPE:
           TYPENAME: RequestOrder
     1:
@@ -221,6 +274,15 @@ SerializedMessage:
         NEWTYPE:
           TYPENAME: AccountInfoResponse
     6:
+      CoinCreationOrder:
+        NEWTYPE:
+          TYPENAME: CoinCreationOrder
+    7:
+      Votes:
+        NEWTYPE:
+          SEQ:
+            TYPENAME: Vote
+    8:
       CrossShardRequest:
         NEWTYPE:
           TYPENAME: CrossShardRequest
@@ -245,6 +307,10 @@ Value:
       Confirm:
         NEWTYPE:
           TYPENAME: Request
+    2:
+      Coin:
+        NEWTYPE:
+          TYPENAME: Coin
 Vote:
   STRUCT:
     - value:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -81,19 +81,11 @@ CoinCreationSource:
   STRUCT:
     - account_id:
         TYPENAME: AccountId
-    - amount:
+    - account_balance:
         TYPENAME: Amount
     - coins:
         SEQ:
           TYPENAME: Certificate
-ConfirmationOutcome:
-  ENUM:
-    0:
-      Complete: UNIT
-    1:
-      Retry: UNIT
-    2:
-      Cancel: UNIT
 CrossShardRequest:
   ENUM:
     0:
@@ -233,6 +225,8 @@ Operation:
               TYPENAME: Address
           - amount:
               TYPENAME: Amount
+          - user_data:
+              TYPENAME: UserData
 PublicKeyBytes:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -25,13 +25,13 @@ AccountInfoResponse:
         TYPENAME: SequenceNumber
     - pending_confirmation:
         OPTION:
-          TYPENAME: SignedRequestOrder
+          TYPENAME: SignedRequest
     - queried_certificate:
         OPTION:
-          TYPENAME: CertifiedRequestOrder
+          TYPENAME: CertifiedRequest
     - queried_received_requests:
         SEQ:
-          TYPENAME: CertifiedRequestOrder
+          TYPENAME: CertifiedRequest
 Address:
   ENUM:
     0:
@@ -46,10 +46,10 @@ Amount:
   NEWTYPESTRUCT: U64
 Balance:
   NEWTYPESTRUCT: I128
-CertifiedRequestOrder:
+CertifiedRequest:
   STRUCT:
     - value:
-        TYPENAME: RequestOrder
+        TYPENAME: Request
     - signatures:
         SEQ:
           TUPLE:
@@ -66,7 +66,7 @@ ConfirmationOutcome:
 CrossShardRequest:
   STRUCT:
     - certificate:
-        TYPENAME: CertifiedRequestOrder
+        TYPENAME: CertifiedRequest
 FastPayError:
   ENUM:
     0:
@@ -98,7 +98,7 @@ FastPayError:
       PreviousRequestMustBeConfirmedFirst:
         STRUCT:
           - pending_confirmation:
-              TYPENAME: RequestOrder
+              TYPENAME: Request
     10:
       ErrorWhileProcessingRequestOrder: UNIT
     11:
@@ -201,11 +201,11 @@ SerializedMessage:
     1:
       Vote:
         NEWTYPE:
-          TYPENAME: SignedRequestOrder
+          TYPENAME: SignedRequest
     2:
       Confirmation:
         NEWTYPE:
-          TYPENAME: CertifiedRequestOrder
+          TYPENAME: CertifiedRequest
     3:
       Error:
         NEWTYPE:
@@ -227,10 +227,10 @@ Signature:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 64
-SignedRequestOrder:
+SignedRequest:
   STRUCT:
     - value:
-        TYPENAME: RequestOrder
+        TYPENAME: Request
     - authority:
         TYPENAME: PublicKeyBytes
     - signature:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -184,6 +184,8 @@ FastPayError:
     29:
       InvalidCoinCreationOrder: UNIT
     30:
+      InvalidCoin: UNIT
+    31:
       ClientIoError:
         STRUCT:
           - error: STR
@@ -224,6 +226,13 @@ Operation:
               TYPENAME: Amount
           - contract_hash:
               TYPENAME: HashValue
+    5:
+      SpendAndTransfer:
+        STRUCT:
+          - recipient:
+              TYPENAME: Address
+          - amount:
+              TYPENAME: Amount
 PublicKeyBytes:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -245,6 +254,9 @@ RequestOrder:
         TYPENAME: PublicKeyBytes
     - signature:
         TYPENAME: Signature
+    - assets:
+        SEQ:
+          TYPENAME: Certificate
 SequenceNumber:
   NEWTYPESTRUCT: U64
 SerializedMessage:


### PR DESCRIPTION
The stack starts with lots of preliminary changes and renaming:
* Operation::Payment -> Operation::Transfer
* pending_confirmation -> pending
* CreateAccount -> OpenAccount
* Transfer -> Request
* TransferOrder -> RequestOrder
* SignedRequestOrder -> Vote (signs a Value = Confirm(Request) | Lock(Request) instead of the initial RequestOrder)
* CertifiedRequestOrder -> Certificate (idem)

Then, we start the "real thing":
* Adding a notion of "coin creation order" (new entry point in parallel to account requests)
* Add two account operations: Spend (to create coins) and SpendAndTransfer (to consume them)