### PR TITLE
allow clients to restrict their RequestOrder to a single authority

### DIFF
--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -151,7 +151,7 @@ impl ClientServerBenchmark {
                 },
                 sequence_number: SequenceNumber::from(0),
             };
-            let order = RequestOrder::new(request.clone(), &key_pair, Vec::new());
+            let order = RequestOrder::new(request.clone().into(), &key_pair, Vec::new());
             let shard = AuthorityState::get_shard(self.num_shards, &id);
 
             // Serialize order

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -108,7 +108,7 @@ fn make_benchmark_request_orders(
         };
         debug!("Preparing request order: {:?}", request);
         account.next_sequence_number = account.next_sequence_number.increment().unwrap();
-        let order = RequestOrder::new(request.clone(), &account.key_pair, Vec::new());
+        let order = RequestOrder::new(request.clone().into(), &account.key_pair, Vec::new());
         orders.push(order.clone());
         let serialized_order = serialize_request_order(&order);
         serialized_orders.push((account.account_id.clone(), serialized_order.into()));
@@ -142,7 +142,7 @@ fn make_benchmark_certificates_from_orders_and_server_configs(
     let mut serialized_certificates = Vec::new();
     for order in orders {
         let mut certificate = Certificate {
-            value: Value::Confirm(order.request.clone()),
+            value: Value::Confirm(order.value.request.clone()),
             signatures: Vec::new(),
         };
         for i in 0..committee.quorum_threshold() {
@@ -151,7 +151,10 @@ fn make_benchmark_certificates_from_orders_and_server_configs(
             certificate.signatures.push((*pubx, sig));
         }
         let serialized_certificate = serialize_cert(&certificate);
-        serialized_certificates.push((order.request.account_id, serialized_certificate.into()));
+        serialized_certificates.push((
+            order.value.request.account_id,
+            serialized_certificate.into(),
+        ));
     }
     serialized_certificates
 }

--- a/fastpay/src/network.rs
+++ b/fastpay/src/network.rs
@@ -321,7 +321,7 @@ impl AuthorityClient for Client {
         order: RequestOrder,
     ) -> AsyncResult<AccountInfoResponse, FastPayError> {
         Box::pin(async move {
-            let shard = AuthorityState::get_shard(self.num_shards, &order.request.account_id);
+            let shard = AuthorityState::get_shard(self.num_shards, &order.value.request.account_id);
             self.send_recv_bytes(shard, serialize_request_order(&order))
                 .await
         })

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -100,6 +100,8 @@ pub enum FastPayError {
     InvalidDecoding,
     #[fail(display = "Unexpected message.")]
     UnexpectedMessage,
+    #[fail(display = "Invalid request order.")]
+    InvalidRequestOrder,
     #[fail(display = "Invalid confirmation order.")]
     InvalidConfirmationOrder,
     #[fail(display = "Invalid coin creation order.")]

--- a/fastpay_core/src/unit_tests/serialize_tests.rs
+++ b/fastpay_core/src/unit_tests/serialize_tests.rs
@@ -65,7 +65,7 @@ fn test_order() {
         },
         sequence_number: SequenceNumber::new(),
     };
-    let request_order = RequestOrder::new(request, &sender_key, Vec::new());
+    let request_order = RequestOrder::new(request.into(), &sender_key, Vec::new());
 
     let buf = serialize_request_order(&request_order);
     let result = deserialize_message(buf.as_slice());
@@ -86,7 +86,7 @@ fn test_order() {
         },
         sequence_number: SequenceNumber::new(),
     };
-    let request_order2 = RequestOrder::new(request2, &sender_key, Vec::new());
+    let request_order2 = RequestOrder::new(request2.into(), &sender_key, Vec::new());
 
     let buf = serialize_request_order(&request_order2);
     let result = deserialize_message(buf.as_slice());
@@ -248,7 +248,7 @@ fn test_time_order() {
     let mut buf = Vec::new();
     let now = Instant::now();
     for _ in 0..100 {
-        let request_order = RequestOrder::new(request.clone(), &sender_key, Vec::new());
+        let request_order = RequestOrder::new(request.clone().into(), &sender_key, Vec::new());
         serialize_request_order_into(&mut buf, &request_order).unwrap();
     }
     println!("Write Order: {} microsec", now.elapsed().as_micros() / 100);

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -172,12 +172,14 @@ FastPayError:
     27:
       UnexpectedMessage: UNIT
     28:
-      InvalidConfirmationOrder: UNIT
+      InvalidRequestOrder: UNIT
     29:
-      InvalidCoinCreationOrder: UNIT
+      InvalidConfirmationOrder: UNIT
     30:
-      InvalidCoin: UNIT
+      InvalidCoinCreationOrder: UNIT
     31:
+      InvalidCoin: UNIT
+    32:
       ClientIoError:
         STRUCT:
           - error: STR
@@ -242,8 +244,8 @@ Request:
         TYPENAME: SequenceNumber
 RequestOrder:
   STRUCT:
-    - request:
-        TYPENAME: Request
+    - value:
+        TYPENAME: RequestValue
     - owner:
         TYPENAME: PublicKeyBytes
     - signature:
@@ -251,6 +253,13 @@ RequestOrder:
     - assets:
         SEQ:
           TYPENAME: Certificate
+RequestValue:
+  STRUCT:
+    - request:
+        TYPENAME: Request
+    - limited_to:
+        OPTION:
+          TYPENAME: PublicKeyBytes
 SequenceNumber:
   NEWTYPESTRUCT: U64
 SerializedMessage:


### PR DESCRIPTION
* Introduce RequestValue, which is a Request + some optional authorty name, meant to be signed within a RequestOrder.