### PR TITLE
Client support for new operations

### DIFF
--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -235,7 +235,7 @@ impl ClientServerBenchmark {
                     info!("Process message {}...", orders.len());
                 }
                 let (shard, order) = orders.pop().unwrap();
-                let status = client.send_recv_bytes(shard, order.to_vec()).await;
+                let status = client.send_recv_info_bytes(shard, order.to_vec()).await;
                 match status {
                     Ok(info) => {
                         debug!("Query response: {:?}", info);

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -4,7 +4,9 @@
 #![deny(warnings)]
 
 use fastpay::{network, transport};
-use fastpay_core::{authority::*, base_types::*, committee::*, messages::*, serialize::*};
+use fastpay_core::{
+    account::AccountState, authority::*, base_types::*, committee::*, messages::*, serialize::*,
+};
 
 use bytes::Bytes;
 use futures::stream::StreamExt;
@@ -131,15 +133,7 @@ impl ClientServerBenchmark {
             let owner = key_pair.public();
             let shard = AuthorityState::get_shard(self.num_shards, &id) as usize;
             assert!(states[shard].in_shard(&id));
-            let client = AccountState {
-                owner: Some(owner),
-                balance: Balance::from(Amount::from(100)),
-                next_sequence_number: SequenceNumber::from(0),
-                pending: None,
-                confirmed_log: Vec::new(),
-                synchronization_log: Vec::new(),
-                received_log: Vec::new(),
-            };
+            let client = AccountState::new(owner, Balance::from(Amount::from(100)));
             states[shard].accounts.insert(id.clone(), client);
 
             let request = Request {

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -64,19 +64,19 @@ fn make_authority_mass_clients(
     authority_clients
 }
 
-fn make_client_state(
+fn make_account_client_state(
     accounts: &AccountsConfig,
     committee_config: &CommitteeConfig,
     account_id: AccountId,
     buffer_size: usize,
     send_timeout: std::time::Duration,
     recv_timeout: std::time::Duration,
-) -> ClientState<network::Client> {
+) -> AccountClientState<network::Client> {
     let account = accounts.get(&account_id).expect("Unknown account");
     let committee = Committee::new(committee_config.voting_rights());
     let authority_clients =
         make_authority_clients(committee_config, buffer_size, send_timeout, recv_timeout);
-    ClientState::new(
+    AccountClientState::new(
         account_id,
         Some(account.key_pair.copy()),
         committee,
@@ -392,7 +392,7 @@ fn main() {
 
             let mut rt = Runtime::new().unwrap();
             rt.block_on(async move {
-                let mut client_state = make_client_state(
+                let mut client_state = make_account_client_state(
                     &accounts_config,
                     &committee_config,
                     sender,
@@ -411,7 +411,7 @@ fn main() {
                 println!("{:?}", cert);
                 accounts_config.update_from_state(&client_state);
                 info!("Updating recipient's local balance");
-                let mut recipient_client_state = make_client_state(
+                let mut recipient_client_state = make_account_client_state(
                     &accounts_config,
                     &committee_config,
                     recipient,
@@ -434,7 +434,7 @@ fn main() {
         ClientCommands::QueryBalance { account_id } => {
             let mut rt = Runtime::new().unwrap();
             rt.block_on(async move {
-                let mut client_state = make_client_state(
+                let mut client_state = make_account_client_state(
                     &accounts_config,
                     &committee_config,
                     account_id,

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -78,7 +78,7 @@ fn make_client_state(
         make_authority_clients(committee_config, buffer_size, send_timeout, recv_timeout);
     ClientState::new(
         account_id,
-        account.key_pair.copy(),
+        Some(account.key_pair.copy()),
         committee,
         authority_clients,
         account.next_sequence_number,

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -82,6 +82,7 @@ fn make_account_client_state(
         committee,
         authority_clients,
         account.next_sequence_number,
+        account.coins.clone(),
         account.sent_certificates.clone(),
         account.received_certificates.clone(),
         account.balance,

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -92,6 +92,7 @@ pub struct UserAccount {
     pub key_pair: KeyPair,
     pub next_sequence_number: SequenceNumber,
     pub balance: Balance,
+    pub coins: Vec<Certificate>,
     pub sent_certificates: Vec<Certificate>,
     pub received_certificates: Vec<Certificate>,
 }
@@ -104,6 +105,7 @@ impl UserAccount {
             key_pair,
             next_sequence_number: SequenceNumber::new(),
             balance,
+            coins: Vec::new(),
             sent_certificates: Vec::new(),
             received_certificates: Vec::new(),
         }

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -149,7 +149,7 @@ impl AccountsConfig {
     pub fn update_for_received_request(&mut self, certificate: Certificate) {
         let request = match &certificate.value {
             Value::Confirm(r) => r,
-            Value::Coin(_) | Value::Lock(_) => return,
+            _ => return,
         };
         if let Operation::Transfer {
             recipient: Address::FastPay(recipient),

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -4,7 +4,7 @@
 use crate::transport::NetworkProtocol;
 use fastpay_core::{
     base_types::*,
-    client::ClientState,
+    client::AccountClientState,
     messages::{Address, Certificate, Operation, Value},
 };
 
@@ -135,7 +135,7 @@ impl AccountsConfig {
         self.accounts.values_mut()
     }
 
-    pub fn update_from_state<A>(&mut self, state: &ClientState<A>) {
+    pub fn update_from_state<A>(&mut self, state: &AccountClientState<A>) {
         let account = self
             .accounts
             .get_mut(state.account_id())

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -4,7 +4,7 @@
 #![deny(warnings)]
 
 use fastpay::{config::*, network, transport};
-use fastpay_core::{authority::*, base_types::*, committee::Committee};
+use fastpay_core::{account::AccountState, authority::*, base_types::*, committee::Committee};
 
 use futures::future::join_all;
 use log::*;
@@ -39,15 +39,7 @@ fn make_shard_server(
         if AuthorityState::get_shard(num_shards, id) != shard {
             continue;
         }
-        let client = AccountState {
-            owner: Some(*owner),
-            balance: *balance,
-            next_sequence_number: SequenceNumber::from(0),
-            pending: None,
-            confirmed_log: Vec::new(),
-            synchronization_log: Vec::new(),
-            received_log: Vec::new(),
-        };
+        let client = AccountState::new(*owner, *balance);
         state.accounts.insert(id.clone(), client);
     }
 

--- a/fastpay_core/src/account.rs
+++ b/fastpay_core/src/account.rs
@@ -1,0 +1,166 @@
+// Copyright (c) Facebook Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{base_types::*, error::FastPayError, messages::*};
+
+/// State of a FastPay account.
+#[derive(Debug, Default)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub struct AccountState {
+    /// Owner of the account. An account without owner cannot execute operations.
+    pub owner: Option<AccountOwner>,
+    /// Balance of the FastPay account.
+    pub balance: Balance,
+    /// Sequence number tracking requests.
+    pub next_sequence_number: SequenceNumber,
+    /// Whether we have signed a request for this sequence number already.
+    pub pending: Option<Vote>,
+    /// All confirmed certificates for this sender.
+    pub confirmed_log: Vec<Certificate>,
+    /// All confirmed certificates as a receiver.
+    pub received_log: Vec<Certificate>,
+    /// All executed Primary synchronization orders for this recipient.
+    pub synchronization_log: Vec<PrimarySynchronizationOrder>,
+}
+
+impl AccountState {
+    pub(crate) fn make_account_info(&self, account_id: AccountId) -> AccountInfoResponse {
+        AccountInfoResponse {
+            account_id,
+            owner: self.owner,
+            balance: self.balance,
+            next_sequence_number: self.next_sequence_number,
+            pending: self.pending.clone(),
+            queried_certificate: None,
+            queried_received_requests: Vec::new(),
+        }
+    }
+
+    pub fn new(owner: AccountOwner, balance: Balance) -> Self {
+        Self {
+            owner: Some(owner),
+            balance,
+            next_sequence_number: SequenceNumber::new(),
+            pending: None,
+            confirmed_log: Vec::new(),
+            synchronization_log: Vec::new(),
+            received_log: Vec::new(),
+        }
+    }
+
+    /// Verify that the operation is valid and return the value to certify.
+    pub(crate) fn validate_operation(
+        &self,
+        request: Request,
+        assets: &[Certificate],
+    ) -> Result<Value, FastPayError> {
+        let value = match &request.operation {
+            Operation::Transfer { amount, .. } => {
+                fp_ensure!(
+                    *amount > Amount::zero(),
+                    FastPayError::IncorrectTransferAmount
+                );
+                fp_ensure!(
+                    self.balance >= (*amount).into(),
+                    FastPayError::InsufficientFunding {
+                        current_balance: self.balance
+                    }
+                );
+                Value::Confirm(request)
+            }
+            Operation::Spend {
+                account_balance, ..
+            } => {
+                fp_ensure!(
+                    self.balance >= (*account_balance).into(),
+                    FastPayError::InsufficientFunding {
+                        current_balance: self.balance
+                    }
+                );
+                Value::Lock(request)
+            }
+            Operation::SpendAndTransfer { amount, .. } => {
+                let mut amount = *amount;
+                // Verify source coins.
+                for coin in assets {
+                    match &coin.value {
+                        Value::Coin(coin) if coin.account_id == request.account_id => {
+                            amount = amount.try_sub(coin.amount)?;
+                        }
+                        _ => fp_bail!(FastPayError::InvalidCoin),
+                    }
+                }
+                // Verify balance.
+                fp_ensure!(
+                    self.balance >= amount.into(),
+                    FastPayError::InsufficientFunding {
+                        current_balance: self.balance
+                    }
+                );
+                Value::Confirm(request)
+            }
+            Operation::OpenAccount { new_id, .. } => {
+                let expected_id = request.account_id.make_child(request.sequence_number);
+                fp_ensure!(
+                    new_id == &expected_id,
+                    FastPayError::InvalidNewAccountId(new_id.clone())
+                );
+                Value::Confirm(request)
+            }
+            Operation::CloseAccount | Operation::ChangeOwner { .. } => {
+                // Nothing to check.
+                Value::Confirm(request)
+            }
+        };
+        Ok(value)
+    }
+
+    /// Execute the sender's side of the operation.
+    pub(crate) fn apply_operation_as_sender(
+        &mut self,
+        operation: &Operation,
+        certificate: Certificate,
+    ) -> Result<(), FastPayError> {
+        match operation {
+            Operation::OpenAccount { .. } => (),
+            Operation::ChangeOwner { new_owner } => {
+                self.owner = Some(*new_owner);
+            }
+            Operation::CloseAccount | Operation::SpendAndTransfer { .. } => {
+                self.owner = None;
+            }
+            Operation::Transfer { amount, .. } => {
+                self.balance = self.balance.try_sub((*amount).into())?;
+            }
+            Operation::Spend { .. } => {
+                // impossible under BFT assumptions.
+                unreachable!("Spend operation are never confirmed");
+            }
+        };
+        self.confirmed_log.push(certificate);
+        Ok(())
+    }
+
+    /// Execute the recipient's side of an operation.
+    pub(crate) fn apply_operation_as_recipient(
+        &mut self,
+        operation: &Operation,
+        certificate: Certificate,
+    ) -> Result<(), FastPayError> {
+        match operation {
+            Operation::Transfer { amount, .. } | Operation::SpendAndTransfer { amount, .. } => {
+                self.balance = self
+                    .balance
+                    .try_add((*amount).into())
+                    .unwrap_or_else(|_| Balance::max());
+            }
+            Operation::OpenAccount { new_owner, .. } => {
+                assert!(self.owner.is_none()); // guaranteed under BFT assumptions.
+                self.owner = Some(*new_owner);
+            }
+            _ => unreachable!("Not an operation with recipients"),
+        }
+        self.received_log.push(certificate);
+        Ok(())
+    }
+}

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -1,32 +1,14 @@
 // Copyright (c) Facebook Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{base_types::*, committee::Committee, error::FastPayError, messages::*};
+use crate::{
+    account::AccountState, base_types::*, committee::Committee, error::FastPayError, messages::*,
+};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 #[cfg(test)]
 #[path = "unit_tests/authority_tests.rs"]
 mod authority_tests;
-
-/// State of a FastPay account.
-#[derive(Debug, Default)]
-#[cfg_attr(test, derive(Eq, PartialEq))]
-pub struct AccountState {
-    /// Owner of the account. An account without owner cannot execute operations.
-    pub owner: Option<AccountOwner>,
-    /// Balance of the FastPay account.
-    pub balance: Balance,
-    /// Sequence number tracking requests.
-    pub next_sequence_number: SequenceNumber,
-    /// Whether we have signed a request for this sequence number already.
-    pub pending: Option<Vote>,
-    /// All confirmed certificates for this sender.
-    pub confirmed_log: Vec<Certificate>,
-    /// All confirmed certificates as a receiver.
-    pub received_log: Vec<Certificate>,
-    /// All executed Primary synchronization orders for this recipient.
-    pub synchronization_log: Vec<PrimarySynchronizationOrder>,
-}
 
 pub struct AuthorityState {
     /// The name of this autority.
@@ -97,52 +79,19 @@ pub trait Authority {
 }
 
 impl AuthorityState {
-    /// (Trusted) Try to update the recipient account in a confirmation order.
-    /// Returns the next action to execute.
-    fn update_recipient_account(&mut self, certificate: Certificate) -> Result<(), FastPayError> {
-        let request = certificate
-            .value
-            .confirm_request()
+    /// (Trusted) Try to update the recipient account(s) in a confirmation order.
+    fn update_recipient_account(
+        &mut self,
+        operation: Operation,
+        certificate: Certificate,
+    ) -> Result<(), FastPayError> {
+        let recipient = operation
+            .recipient()
             .ok_or(FastPayError::InvalidCrossShardRequest)?;
+        fp_ensure!(self.in_shard(recipient), FastPayError::WrongShard);
         // Execute the recipient's side of the operation.
-        match &request.operation {
-            Operation::Transfer {
-                recipient: Address::FastPay(recipient),
-                amount,
-                ..
-            }
-            | Operation::SpendAndTransfer {
-                recipient: Address::FastPay(recipient),
-                amount,
-                ..
-            } => {
-                fp_ensure!(self.in_shard(recipient), FastPayError::WrongShard);
-                let account = self.accounts.entry(recipient.clone()).or_default();
-                account.balance = account
-                    .balance
-                    .try_add((*amount).into())
-                    .unwrap_or_else(|_| Balance::max());
-                account.received_log.push(certificate.clone());
-            }
-            Operation::OpenAccount { new_id, new_owner } => {
-                fp_ensure!(self.in_shard(new_id), FastPayError::WrongShard);
-                let account = self.accounts.entry(new_id.clone()).or_default();
-                assert!(account.owner.is_none()); // guaranteed under BFT assumptions.
-                account.owner = Some(*new_owner);
-                account.received_log.push(certificate.clone());
-            }
-            Operation::CloseAccount
-            | Operation::Transfer {
-                recipient: Address::Primary(_),
-                ..
-            }
-            | Operation::SpendAndTransfer {
-                recipient: Address::Primary(_),
-                ..
-            }
-            | Operation::Spend { .. }
-            | Operation::ChangeOwner { .. } => fp_bail!(FastPayError::InvalidCrossShardRequest),
-        }
+        let account = self.accounts.entry(recipient.clone()).or_default();
+        account.apply_operation_as_recipient(&operation, certificate)?;
         // This concludes the confirmation of `certificate`.
         Ok(())
     }
@@ -161,6 +110,10 @@ impl Authority for AuthorityState {
         // Verify that is the order was meant for this authority.
         if let Some(authority) = &order.value.limited_to {
             fp_ensure!(self.name == *authority, FastPayError::InvalidRequestOrder);
+        }
+        // Verify additional certificates in the order.
+        for asset in &order.assets {
+            asset.check(&self.committee)?;
         }
         let account_id = order.value.request.account_id.clone();
         match self.accounts.get_mut(&account_id) {
@@ -187,66 +140,8 @@ impl Authority for AuthorityState {
                     account.next_sequence_number == request.sequence_number,
                     FastPayError::UnexpectedSequenceNumber
                 );
-                // Verify that the request is "safe", and return the value of the vote.
-                let value = match &request.operation {
-                    Operation::Transfer { amount, .. } => {
-                        fp_ensure!(
-                            *amount > Amount::zero(),
-                            FastPayError::IncorrectTransferAmount
-                        );
-                        fp_ensure!(
-                            account.balance >= (*amount).into(),
-                            FastPayError::InsufficientFunding {
-                                current_balance: account.balance
-                            }
-                        );
-                        Value::Confirm(request)
-                    }
-                    Operation::Spend {
-                        account_balance, ..
-                    } => {
-                        fp_ensure!(
-                            account.balance >= (*account_balance).into(),
-                            FastPayError::InsufficientFunding {
-                                current_balance: account.balance
-                            }
-                        );
-                        Value::Lock(request)
-                    }
-                    Operation::SpendAndTransfer { amount, .. } => {
-                        let mut amount = *amount;
-                        // Verify source coins.
-                        for coin in order.assets {
-                            coin.check(&self.committee)?;
-                            match &coin.value {
-                                Value::Coin(coin) if coin.account_id == account_id => {
-                                    amount = amount.try_sub(coin.amount)?;
-                                }
-                                _ => fp_bail!(FastPayError::InvalidCoin),
-                            }
-                        }
-                        // Verify balance.
-                        fp_ensure!(
-                            account.balance >= amount.into(),
-                            FastPayError::InsufficientFunding {
-                                current_balance: account.balance
-                            }
-                        );
-                        Value::Confirm(request)
-                    }
-                    Operation::OpenAccount { new_id, .. } => {
-                        let expected_id = account_id.make_child(request.sequence_number);
-                        fp_ensure!(
-                            new_id == &expected_id,
-                            FastPayError::InvalidNewAccountId(new_id.clone())
-                        );
-                        Value::Confirm(request)
-                    }
-                    Operation::CloseAccount | Operation::ChangeOwner { .. } => {
-                        // Nothing to check.
-                        Value::Confirm(request)
-                    }
-                };
+                // Verify that the request is safe, and return the value of the vote.
+                let value = account.validate_operation(request, &order.assets)?;
                 let vote = Vote::new(value, &self.key_pair);
                 account.pending = Some(vote);
                 Ok(account.make_account_info(account_id))
@@ -289,39 +184,23 @@ impl Authority for AuthorityState {
             return Ok((info, CrossShardContinuation::Done));
         }
 
+        // Execute the sender's side of the operation.
+        sender_account.apply_operation_as_sender(&request.operation, certificate.clone())?;
         // Advance to next sequence number.
         sender_account.next_sequence_number = sender_account.next_sequence_number.increment()?;
         sender_account.pending = None;
-        sender_account.confirmed_log.push(certificate.clone());
-
-        // Execute the sender's side of the operation.
-        let info = match &request.operation {
-            Operation::OpenAccount { .. } => sender_account.make_account_info(sender.clone()),
-            Operation::ChangeOwner { new_owner } => {
-                sender_account.owner = Some(*new_owner);
-                sender_account.make_account_info(sender.clone())
-            }
-            Operation::CloseAccount | Operation::SpendAndTransfer { .. } => {
-                let mut info = sender_account.make_account_info(sender.clone());
-                self.accounts.remove(&sender);
-                info.owner = None; // Signal that the account was deleted.
-                info
-            }
-            Operation::Transfer { amount, .. } => {
-                sender_account.balance = sender_account.balance.try_sub((*amount).into())?;
-                sender_account.make_account_info(sender.clone())
-            }
-            Operation::Spend { .. } => {
-                // unreachable under BFT assumption
-                fp_bail!(FastPayError::InvalidConfirmationOrder)
-            }
-        };
+        // Final touch on the sender's account.
+        let info = sender_account.make_account_info(sender.clone());
+        if sender_account.owner.is_none() {
+            // Remove inactive account.
+            self.accounts.remove(&sender);
+        }
 
         if let Some(recipient) = request.operation.recipient() {
             // Update recipient.
             if self.in_shard(recipient) {
                 // Execute the operation locally.
-                self.update_recipient_account(certificate)?;
+                self.update_recipient_account(request.operation.clone(), certificate)?;
             } else {
                 // Initiate a cross-shard request.
                 let shard_id = self.which_shard(recipient);
@@ -471,7 +350,11 @@ impl Authority for AuthorityState {
     ) -> Result<(), FastPayError> {
         match request {
             CrossShardRequest::UpdateRecipient { certificate } => {
-                self.update_recipient_account(certificate)
+                let request = certificate
+                    .value
+                    .confirm_request()
+                    .ok_or(FastPayError::InvalidCrossShardRequest)?;
+                self.update_recipient_account(request.operation.clone(), certificate)
             }
             CrossShardRequest::DestroyAccount { account_id } => {
                 fp_ensure!(self.in_shard(&account_id), FastPayError::WrongShard);
@@ -499,37 +382,6 @@ impl Authority for AuthorityState {
             response.queried_received_requests = account.received_log[idx..].to_vec();
         }
         Ok(response)
-    }
-}
-
-impl AccountState {
-    fn make_account_info(&self, account_id: AccountId) -> AccountInfoResponse {
-        AccountInfoResponse {
-            account_id,
-            owner: self.owner,
-            balance: self.balance,
-            next_sequence_number: self.next_sequence_number,
-            pending: self.pending.clone(),
-            queried_certificate: None,
-            queried_received_requests: Vec::new(),
-        }
-    }
-
-    #[cfg(test)]
-    pub fn new_with_balance(
-        owner: AccountOwner,
-        balance: Balance,
-        received_log: Vec<Certificate>,
-    ) -> Self {
-        Self {
-            owner: Some(owner),
-            balance,
-            next_sequence_number: SequenceNumber::new(),
-            pending: None,
-            confirmed_log: Vec::new(),
-            synchronization_log: Vec::new(),
-            received_log,
-        }
     }
 }
 

--- a/fastpay_core/src/base_types.rs
+++ b/fastpay_core/src/base_types.rs
@@ -322,6 +322,12 @@ impl std::fmt::Display for Balance {
     }
 }
 
+impl std::fmt::Display for Amount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl std::str::FromStr for Balance {
     type Err = std::num::ParseIntError;
 

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -27,8 +27,8 @@ pub enum FastPayError {
     // Signature verification
     #[fail(display = "Request was not signed by an authorized owner")]
     InvalidOwner,
-    #[fail(display = "Signature is not valid: {}", error)]
-    InvalidSignature { error: String },
+    #[fail(display = "Signature for object {} is not valid: {}", type_name, error)]
+    InvalidSignature { error: String, type_name: String },
     #[fail(display = "Value was not signed by a known authority")]
     UnknownSigner,
     // Certificate verification
@@ -37,8 +37,6 @@ pub enum FastPayError {
     // Transfer processing
     #[fail(display = "Transfers must have positive amount")]
     IncorrectTransferAmount,
-    #[fail(display = "Account is still pending confirmation of creation")]
-    AccountIsNotReady,
     #[fail(
         display = "The given sequence number must match the next expected sequence number of the account"
     )]
@@ -74,8 +72,8 @@ pub enum FastPayError {
     // Account access
     #[fail(display = "No certificate for this account and sequence number")]
     CertificateNotfound,
-    #[fail(display = "Unknown sender's account {:?}", 0)]
-    UnknownSenderAccount(AccountId),
+    #[fail(display = "The account being queried is not active {:?}", 0)]
+    InactiveAccount(AccountId),
     #[fail(display = "Signatures in a certificate must be from different authorities.")]
     CertificateAuthorityReuse,
     #[fail(display = "Sequence numbers above the maximal value are not usable for requests.")]

--- a/fastpay_core/src/lib.rs
+++ b/fastpay_core/src/lib.rs
@@ -6,6 +6,7 @@
 #[macro_use]
 pub mod error;
 
+pub mod account;
 pub mod authority;
 pub mod base_types;
 pub mod client;

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -206,9 +206,31 @@ impl Operation {
             | ChangeOwner { .. } => None,
         }
     }
+
+    pub fn received_amount(&self) -> Option<Amount> {
+        use Operation::*;
+        match self {
+            Transfer { amount, .. } | Operation::SpendAndTransfer { amount, .. } => Some(*amount),
+            _ => None,
+        }
+    }
 }
 
 impl Value {
+    pub fn coin_amount(&self) -> Option<Amount> {
+        match self {
+            Value::Coin(coin) => Some(coin.amount),
+            _ => None,
+        }
+    }
+
+    pub fn coin_account_id(&self) -> Option<&AccountId> {
+        match self {
+            Value::Coin(coin) => Some(&coin.account_id),
+            _ => None,
+        }
+    }
+
     pub fn confirm_account_id(&self) -> Option<&AccountId> {
         match self {
             Value::Confirm(r) => Some(&r.account_id),

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -89,6 +89,7 @@ pub struct RequestOrder {
 pub struct Coin {
     pub account_id: AccountId,
     pub amount: Amount,
+    pub seed: u128,
 }
 
 /// A statement to be certified by the authorities.
@@ -113,8 +114,6 @@ pub struct CoinCreationSource {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct CoinCreationContract {
-    /// Diversification seed to ensure that hash(contract) cannot be guessed.
-    pub seed: u128,
     /// The sources to be used for coin creation.
     pub sources: Vec<CoinCreationSource>,
     /// The coins to be created.

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -310,7 +310,15 @@ fn test_update_recipient_account() {
         Amount::from(10),
         &state,
     );
-    assert!(state.update_recipient_account(certificate).is_ok());
+    let operation = certificate
+        .value
+        .confirm_request()
+        .unwrap()
+        .operation
+        .clone();
+    assert!(state
+        .update_recipient_account(operation, certificate)
+        .is_ok());
     let account = state.accounts.get(&dbg_account(2)).unwrap();
     assert_eq!(Balance::from(11), account.balance);
     assert_eq!(SequenceNumber::from(0), account.next_sequence_number);
@@ -486,7 +494,7 @@ fn init_state_with_accounts<I: IntoIterator<Item = (AccountId, AccountOwner, Bal
 ) -> AuthorityState {
     let mut state = init_state();
     for (id, owner, balance) in balances {
-        let account = AccountState::new_with_balance(owner, balance, Vec::new());
+        let account = AccountState::new(owner, balance);
         state.accounts.insert(id, account);
     }
     state

--- a/fastpay_core/src/unit_tests/base_types_tests.rs
+++ b/fastpay_core/src/unit_tests/base_types_tests.rs
@@ -5,12 +5,12 @@
 
 use super::*;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct Foo(String);
 
 impl BcsSignable for Foo {}
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct Bar(String);
 
 impl BcsSignable for Bar {}

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -107,9 +107,9 @@ fn make_client(
     account_id: AccountId,
     authority_clients: HashMap<AuthorityName, LocalAuthorityClient>,
     committee: Committee,
-) -> ClientState<LocalAuthorityClient> {
+) -> AccountClientState<LocalAuthorityClient> {
     let key_pair = get_key_pair();
-    ClientState::new(
+    AccountClientState::new(
         account_id,
         Some(key_pair),
         committee,
@@ -136,7 +136,7 @@ fn fund_account<I: IntoIterator<Item = i128>>(
     }
 }
 
-fn init_local_client_state(balances: Vec<i128>) -> ClientState<LocalAuthorityClient> {
+fn init_local_client_state(balances: Vec<i128>) -> AccountClientState<LocalAuthorityClient> {
     let (mut authority_clients, committee) = init_local_authorities(balances.len());
     let zeroes = vec![0; balances.len()];
     let client1 = make_client(dbg_account(1), authority_clients.clone(), committee.clone());
@@ -158,7 +158,7 @@ fn init_local_client_state(balances: Vec<i128>) -> ClientState<LocalAuthorityCli
 
 fn init_local_client_state_with_bad_authority(
     balances: Vec<i128>,
-) -> ClientState<LocalAuthorityClient> {
+) -> AccountClientState<LocalAuthorityClient> {
     let (mut authority_clients, committee) = init_local_authorities_bad_1(balances.len());
     let zeroes = vec![0; balances.len()];
     let client1 = make_client(dbg_account(1), authority_clients.clone(), committee.clone());
@@ -306,11 +306,11 @@ fn test_open_account() {
         }) if &new_id == id
     ));
     // Make a client to try the new account.
-    let mut client = ClientState::new(
+    let mut client = AccountClientState::new(
         new_id,
         Some(new_key_pair),
         sender.committee.clone(),
-        sender.authority_clients.clone(),
+        sender.authority_clients,
         SequenceNumber::from(0),
         Vec::new(),
         Vec::new(),

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -4,7 +4,8 @@
 
 use super::*;
 use crate::{
-    authority::{AccountState, Authority, AuthorityState},
+    account::AccountState,
+    authority::{Authority, AuthorityState},
     base_types::Amount,
 };
 use futures::lock::Mutex;
@@ -134,11 +135,7 @@ fn fund_account<I: IntoIterator<Item = i128>>(
     for (_, client) in clients.iter_mut() {
         client.0.as_ref().try_lock().unwrap().accounts_mut().insert(
             account_id.clone(),
-            AccountState::new_with_balance(
-                owner,
-                balances.next().unwrap_or_else(Balance::zero),
-                /* no receive log to justify the balances */ Vec::new(),
-            ),
+            AccountState::new(owner, balances.next().unwrap_or_else(Balance::zero)),
         );
     }
 }

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -61,9 +61,9 @@ Coin:
         TYPENAME: AccountId
     - amount:
         TYPENAME: Amount
+    - seed: U128
 CoinCreationContract:
   STRUCT:
-    - seed: U128
     - sources:
         SEQ:
           TYPENAME: CoinCreationSource

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -110,6 +110,7 @@ FastPayError:
       InvalidSignature:
         STRUCT:
           - error: STR
+          - type_name: STR
     2:
       UnknownSigner: UNIT
     3:
@@ -117,73 +118,71 @@ FastPayError:
     4:
       IncorrectTransferAmount: UNIT
     5:
-      AccountIsNotReady: UNIT
-    6:
       UnexpectedSequenceNumber: UNIT
-    7:
+    6:
       InsufficientFunding:
         STRUCT:
           - current_balance:
               TYPENAME: Balance
-    8:
+    7:
       InvalidNewAccountId:
         NEWTYPE:
           TYPENAME: AccountId
-    9:
+    8:
       PreviousRequestMustBeConfirmedFirst:
         STRUCT:
           - pending:
               TYPENAME: Value
-    10:
+    9:
       ErrorWhileProcessingRequestOrder: UNIT
-    11:
+    10:
       ErrorWhileRequestingCertificate: UNIT
-    12:
+    11:
       MissingEarlierConfirmations:
         STRUCT:
           - current_sequence_number:
               TYPENAME: SequenceNumber
-    13:
+    12:
       UnexpectedTransactionIndex: UNIT
-    14:
+    13:
       CertificateNotfound: UNIT
-    15:
-      UnknownSenderAccount:
+    14:
+      InactiveAccount:
         NEWTYPE:
           TYPENAME: AccountId
-    16:
+    15:
       CertificateAuthorityReuse: UNIT
-    17:
+    16:
       InvalidSequenceNumber: UNIT
-    18:
+    17:
       SequenceOverflow: UNIT
-    19:
+    18:
       SequenceUnderflow: UNIT
-    20:
+    19:
       AmountOverflow: UNIT
-    21:
+    20:
       AmountUnderflow: UNIT
-    22:
+    21:
       BalanceOverflow: UNIT
-    23:
+    22:
       BalanceUnderflow: UNIT
-    24:
+    23:
       WrongShard: UNIT
-    25:
+    24:
       InvalidCrossShardRequest: UNIT
-    26:
+    25:
       InvalidDecoding: UNIT
-    27:
+    26:
       UnexpectedMessage: UNIT
-    28:
+    27:
       InvalidRequestOrder: UNIT
-    29:
+    28:
       InvalidConfirmationOrder: UNIT
-    30:
+    29:
       InvalidCoinCreationOrder: UNIT
-    31:
+    30:
       InvalidCoin: UNIT
-    32:
+    31:
       ClientIoError:
         STRUCT:
           - error: STR


### PR DESCRIPTION
This adds a preliminary support for the new account management operations and the coin operations.
* [safety fix] add seeds in transparent coins and check for uniqueness
* [client] support ownership transfers, key rotations, account creation, etc
* [client] support coin operations
* [cli] surface the two methods to query balances 