### PR TITLE
[account] De-duplicate cross-shard requests

### DIFF
--- a/fastpay/Cargo.toml
+++ b/fastpay/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
 structopt = "0.3"
 tempfile = "3.2.0"
-tokio = { version = "0.2.22", features = ["full"] }
+tokio = { version = "1.12.0", features = ["full"] }
 
 fastpay_core = { path = "../fastpay_core" }
 

--- a/fastpay/Cargo.toml
+++ b/fastpay/Cargo.toml
@@ -6,17 +6,17 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = "0.5.6"
+bytes = "1.1.0"
 clap = "2.33.3"
-env_logger = "0.7.1"
+env_logger = "0.9.0"
 failure = "0.1.8"
-futures = "0.3.5"
-log = "0.4.11"
-net2 = "0.2.34"
-rand = "0.8.4"
-serde = { version = "1.0.115", features = ["derive"] }
-serde_json = "1.0.57"
-structopt = "0.3"
+futures = "0.3.17"
+log = "0.4.14"
+net2 = "0.2.37"
+rand = "0.7.3"
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"
+structopt = "0.3.23"
 tempfile = "3.2.0"
 tokio = { version = "1.12.0", features = ["full"] }
 

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -72,9 +72,8 @@ fn main() {
         // Make special single-core runtime for each server
         let b = benchmark.clone();
         thread::spawn(move || {
-            let mut runtime = Builder::new()
+            let runtime = Builder::new_current_thread()
                 .enable_all()
-                .basic_scheduler()
                 .thread_stack_size(15 * 1024 * 1024)
                 .build()
                 .unwrap();
@@ -88,9 +87,8 @@ fn main() {
         });
     }
 
-    let mut runtime = Builder::new()
+    let runtime = Builder::new_current_thread()
         .enable_all()
-        .basic_scheduler()
         .thread_stack_size(15 * 1024 * 1024)
         .build()
         .unwrap();
@@ -190,7 +188,7 @@ impl ClientServerBenchmark {
     }
 
     async fn launch_client(&self, mut orders: Vec<(u32, Bytes)>) {
-        time::delay_for(Duration::from_millis(1000)).await;
+        time::sleep(Duration::from_millis(1000)).await;
 
         let items_number = orders.len() / 2;
         let time_start = Instant::now();

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -3,7 +3,7 @@
 
 #![deny(warnings)]
 
-use fastpay::{network, transport};
+use fastpay::{network, network::CrossShardConfig, transport};
 use fastpay_core::{
     account::AccountState, authority::*, base_types::*, committee::*, messages::*, serialize::*,
 };
@@ -56,9 +56,9 @@ struct ClientServerBenchmark {
     /// Maximum size of datagrams received and sent (bytes)
     #[structopt(long, default_value = transport::DEFAULT_MAX_DATAGRAM_SIZE)]
     buffer_size: usize,
-    /// Number of cross shards messages allowed before blocking the main server loop
-    #[structopt(long, default_value = "1")]
-    cross_shard_queue_size: usize,
+    /// Configuration for cross shard requests
+    #[structopt(flatten)]
+    cross_shard_config: CrossShardConfig,
 }
 
 fn main() {
@@ -182,7 +182,7 @@ impl ClientServerBenchmark {
             self.port,
             state,
             self.buffer_size,
-            self.cross_shard_queue_size,
+            self.cross_shard_config.clone(),
         );
         server.spawn().await.unwrap()
     }

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -62,7 +62,7 @@ struct ClientServerBenchmark {
 }
 
 fn main() {
-    env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let benchmark = ClientServerBenchmark::from_args();
 
     let (states, orders) = benchmark.make_structures();

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -506,7 +506,7 @@ enum ClientCommands {
 }
 
 fn main() {
-    env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let options = ClientOptions::from_args();
     let mut context = ClientContext::from_options(&options);
     let rt = Runtime::new().unwrap();

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -509,7 +509,7 @@ fn main() {
     env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let options = ClientOptions::from_args();
     let mut context = ClientContext::from_options(&options);
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     match options.cmd {
         ClientCommands::Transfer {
             sender,

--- a/fastpay/src/network.rs
+++ b/fastpay/src/network.rs
@@ -8,7 +8,21 @@ use bytes::Bytes;
 use futures::{channel::mpsc, future::FutureExt, sink::SinkExt, stream::StreamExt};
 use log::*;
 use std::io;
+use structopt::StructOpt;
 use tokio::time;
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct CrossShardConfig {
+    /// Number of cross shards messages allowed before blocking the main server loop
+    #[structopt(long = "cross_shard_queue_size", default_value = "1")]
+    queue_size: usize,
+    /// Maximum number of retries for a cross shard message.
+    #[structopt(long = "cross_shard_max_retries", default_value = "10")]
+    max_retries: usize,
+    /// Delay before retrying of cross-shard message.
+    #[structopt(long = "cross_shard_retry_delay_ms", default_value = "2000")]
+    retry_delay_ms: u64,
+}
 
 pub struct Server {
     network_protocol: NetworkProtocol,
@@ -16,7 +30,7 @@ pub struct Server {
     base_port: u32,
     state: AuthorityState,
     buffer_size: usize,
-    cross_shard_queue_size: usize,
+    cross_shard_config: CrossShardConfig,
     // Stats
     packets_processed: u64,
     user_errors: u64,
@@ -29,7 +43,7 @@ impl Server {
         base_port: u32,
         state: AuthorityState,
         buffer_size: usize,
-        cross_shard_queue_size: usize,
+        cross_shard_config: CrossShardConfig,
     ) -> Self {
         Self {
             network_protocol,
@@ -37,7 +51,7 @@ impl Server {
             base_port,
             state,
             buffer_size,
-            cross_shard_queue_size,
+            cross_shard_config,
             packets_processed: 0,
             user_errors: 0,
         }
@@ -55,6 +69,8 @@ impl Server {
         network_protocol: NetworkProtocol,
         base_address: String,
         base_port: u32,
+        cross_shard_max_retries: usize,
+        cross_shard_retry_delay_ms: u64,
         this_shard: ShardId,
         mut receiver: mpsc::Receiver<(Vec<u8>, ShardId)>,
     ) {
@@ -67,21 +83,41 @@ impl Server {
         while let Some((buf, shard)) = receiver.next().await {
             // Send cross-shard query.
             let remote_address = format!("{}:{}", base_address, base_port + shard);
-            let status = pool.send_data_to(&buf, &remote_address).await;
-            if let Err(error) = status {
-                error!("Failed to send cross-shard query: {}", error);
-            } else {
-                debug!("Sent cross shard query: {} -> {}", this_shard, shard);
-                queries_sent += 1;
-                if queries_sent % 2000 == 0 {
-                    info!(
-                        "{}:{} (shard {}) has sent {} cross-shard queries",
-                        base_address,
-                        base_port + this_shard,
-                        this_shard,
-                        queries_sent
-                    );
+            for i in 0..cross_shard_max_retries {
+                let status = pool.send_data_to(&buf, &remote_address).await;
+                match status {
+                    Err(error) => {
+                        if i < cross_shard_max_retries {
+                            error!(
+                                "Failed to send cross-shard query ({}-th retry): {}",
+                                i, error
+                            );
+                            tokio::time::sleep(tokio::time::Duration::from_millis(
+                                cross_shard_retry_delay_ms,
+                            ))
+                            .await;
+                        } else {
+                            error!(
+                                "Failed to send cross-shard query (giving up after {} retries): {}",
+                                i, error
+                            );
+                        }
+                    }
+                    _ => {
+                        debug!("Sent cross shard query: {} -> {}", this_shard, shard);
+                        queries_sent += 1;
+                        break;
+                    }
                 }
+            }
+            if queries_sent % 2000 == 0 {
+                info!(
+                    "{}:{} (shard {}) has sent {} cross-shard queries",
+                    base_address,
+                    base_port + this_shard,
+                    this_shard,
+                    queries_sent
+                );
             }
         }
     }
@@ -99,11 +135,14 @@ impl Server {
             self.base_port + self.state.shard_id
         );
 
-        let (cross_shard_sender, cross_shard_receiver) = mpsc::channel(self.cross_shard_queue_size);
+        let (cross_shard_sender, cross_shard_receiver) =
+            mpsc::channel(self.cross_shard_config.queue_size);
         tokio::spawn(Self::forward_cross_shard_queries(
             self.network_protocol,
             self.base_address.clone(),
             self.base_port,
+            self.cross_shard_config.max_retries,
+            self.cross_shard_config.retry_delay_ms,
             self.state.shard_id,
             cross_shard_receiver,
         ));

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -19,7 +19,7 @@ fn make_shard_server(
     committee_config_path: &Path,
     initial_accounts_config_path: &Path,
     buffer_size: usize,
-    cross_shard_queue_size: usize,
+    cross_shard_config: network::CrossShardConfig,
     shard: u32,
 ) -> network::Server {
     let server_config =
@@ -50,7 +50,7 @@ fn make_shard_server(
         server_config.authority.base_port,
         state,
         buffer_size,
-        cross_shard_queue_size,
+        cross_shard_config,
     )
 }
 
@@ -60,7 +60,7 @@ fn make_servers(
     committee_config_path: &Path,
     initial_accounts_config_path: &Path,
     buffer_size: usize,
-    cross_shard_queue_size: usize,
+    cross_shard_config: network::CrossShardConfig,
 ) -> Vec<network::Server> {
     let server_config =
         AuthorityServerConfig::read(server_config_path).expect("Fail to read server config");
@@ -74,7 +74,7 @@ fn make_servers(
             committee_config_path,
             initial_accounts_config_path,
             buffer_size,
-            cross_shard_queue_size,
+            cross_shard_config.clone(),
             shard,
         ))
     }
@@ -105,9 +105,9 @@ enum ServerCommands {
         #[structopt(long, default_value = transport::DEFAULT_MAX_DATAGRAM_SIZE)]
         buffer_size: usize,
 
-        /// Number of cross shards messages allowed before blocking the main server loop
-        #[structopt(long, default_value = "1000")]
-        cross_shard_queue_size: usize,
+        /// Configuration for cross shard requests
+        #[structopt(flatten)]
+        cross_shard_config: network::CrossShardConfig,
 
         /// Path to the file containing the public description of all authorities in this FastPay committee
         #[structopt(long)]
@@ -152,7 +152,7 @@ fn main() {
     match options.cmd {
         ServerCommands::Run {
             buffer_size,
-            cross_shard_queue_size,
+            cross_shard_config,
             committee,
             initial_accounts,
             shard,
@@ -167,7 +167,7 @@ fn main() {
                         &committee,
                         &initial_accounts,
                         buffer_size,
-                        cross_shard_queue_size,
+                        cross_shard_config,
                         shard,
                     );
                     vec![server]
@@ -180,7 +180,7 @@ fn main() {
                         &committee,
                         &initial_accounts,
                         buffer_size,
-                        cross_shard_queue_size,
+                        cross_shard_config,
                     )
                 }
             };

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -144,7 +144,7 @@ enum ServerCommands {
 }
 
 fn main() {
-    env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let options = ServerOptions::from_args();
 
     let server_config_path = &options.server;

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -185,7 +185,7 @@ fn main() {
                 }
             };
 
-            let mut rt = Runtime::new().unwrap();
+            let rt = Runtime::new().unwrap();
             let mut handles = Vec::new();
             for server in servers {
                 handles.push(async move {

--- a/fastpay/src/transport.rs
+++ b/fastpay/src/transport.rs
@@ -7,8 +7,8 @@ use log::*;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryInto, io, sync::Arc};
 use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     net::{TcpListener, TcpStream, UdpSocket},
-    prelude::*,
 };
 
 #[cfg(test)]
@@ -187,7 +187,7 @@ impl DataStreamPool for UdpDataStreamPool {
 // Server implementation for UDP.
 impl NetworkProtocol {
     async fn run_udp_server<S>(
-        mut socket: UdpSocket,
+        socket: UdpSocket,
         mut state: S,
         mut exit_future: futures::channel::oneshot::Receiver<()>,
         buffer_size: usize,
@@ -225,8 +225,6 @@ struct TcpDataStream {
 impl TcpDataStream {
     async fn connect(address: String, max_data_size: usize) -> Result<Self, std::io::Error> {
         let stream = TcpStream::connect(address).await?;
-        stream.set_send_buffer_size(max_data_size)?;
-        stream.set_recv_buffer_size(max_data_size)?;
         Ok(Self {
             stream,
             max_data_size,
@@ -323,7 +321,7 @@ impl DataStreamPool for TcpDataStreamPool {
 // Server implementation for TCP.
 impl NetworkProtocol {
     async fn run_tcp_server<S>(
-        mut listener: TcpListener,
+        listener: TcpListener,
         state: S,
         mut exit_future: futures::channel::oneshot::Receiver<()>,
         buffer_size: usize,
@@ -341,8 +339,6 @@ impl NetworkProtocol {
                         value?
                     }
                 };
-            socket.set_send_buffer_size(buffer_size)?;
-            socket.set_recv_buffer_size(buffer_size)?;
             let guarded_state = guarded_state.clone();
             tokio::spawn(async move {
                 loop {

--- a/fastpay/src/unit_tests/transport_tests.rs
+++ b/fastpay/src/unit_tests/transport_tests.rs
@@ -77,7 +77,7 @@ async fn test_server(protocol: NetworkProtocol) -> Result<(usize, usize), std::i
 
 #[test]
 fn udp_server() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let (processed, received) = rt.block_on(test_server(NetworkProtocol::Udp)).unwrap();
     assert_eq!(processed, 13);
     assert_eq!(received, 10);
@@ -85,7 +85,7 @@ fn udp_server() {
 
 #[test]
 fn tcp_server() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let (processed, received) = rt.block_on(test_server(NetworkProtocol::Tcp)).unwrap();
     // Active TCP connections are allowed to finish before the server is gracefully killed.
     assert_eq!(processed, 17);

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -7,25 +7,25 @@ edition = "2018"
 
 [dependencies]
 bcs = "0.1.3"
-bincode = "1.3.1"
+bincode = "1.3.3"
 failure = "0.1.8"
-futures = "0.3.5"
+futures = "0.3.17"
 generic-array = { version = "0.14.4", features = ["serde"] }
 hex = "0.4.3"
 rand = "0.7.3"
-serde = { version = "1.0.115", features = ["derive"] }
+serde = { version = "1.0.130", features = ["derive"] }
 tokio = { version = "1.12.0", features = ["full"] }
-ed25519 = { version = "1.0.1"}
+ed25519 = "1.2.0"
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
-serde_json = "1.0.57"
-serde-name = "0.1.2"
+serde_json = "1.0.68"
+serde-name = "0.2.0"
 sha2 = "0.9.8"
-structopt = "0.3.21"
+structopt = "0.3.23"
 
 [dev-dependencies]
-similar-asserts = { version = "1.1.0" }
-serde-reflection = "0.3.2"
-serde_yaml = "0.8.17"
+similar-asserts = "1.1.0"
+serde-reflection = "0.3.5"
+serde_yaml = "0.8.21"
 
 [[example]]
 name = "generate-format"

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -14,7 +14,7 @@ generic-array = { version = "0.14.4", features = ["serde"] }
 hex = "0.4.3"
 rand = "0.7.3"
 serde = { version = "1.0.115", features = ["derive"] }
-tokio = { version = "0.2.22", features = ["full"] }
+tokio = { version = "1.12.0", features = ["full"] }
 ed25519 = { version = "1.0.1"}
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 serde_json = "1.0.57"

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -195,7 +195,7 @@ fn init_local_client_state_with_bad_authority(
 
 #[test]
 fn test_get_strong_majority_balance() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     rt.block_on(async {
         let mut client = init_local_client_state(vec![3, 4, 4, 4]);
         assert_eq!(
@@ -219,7 +219,7 @@ fn test_get_strong_majority_balance() {
 
 #[test]
 fn test_initiating_valid_transfer() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let mut sender = init_local_client_state(vec![2, 4, 4, 4]);
     sender.balance = Balance::from(4);
     let certificate = rt
@@ -244,7 +244,7 @@ fn test_initiating_valid_transfer() {
 
 #[test]
 fn test_rotate_key_pair() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let mut sender = init_local_client_state(vec![2, 4, 4, 4]);
     sender.balance = Balance::from(4);
     let new_key_pair = KeyPair::generate();
@@ -273,7 +273,7 @@ fn test_rotate_key_pair() {
 
 #[test]
 fn test_transfer_ownership() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let mut sender = init_local_client_state(vec![2, 4, 4, 4]);
     sender.balance = Balance::from(4);
     let new_key_pair = KeyPair::generate();
@@ -380,7 +380,7 @@ fn test_create_multiple_coins_balance_exceeded() {
 }
 
 fn create_and_transfer_coins(coins: Vec<Coin>) -> Result<(), failure::Error> {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let (mut authority_clients, committee) = init_local_authorities(4);
     let mut client1 = make_client(dbg_account(1), authority_clients.clone(), committee.clone());
     fund_account(
@@ -448,7 +448,7 @@ fn create_and_transfer_coins(coins: Vec<Coin>) -> Result<(), failure::Error> {
 
 #[test]
 fn test_open_account() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let mut sender = init_local_client_state(vec![2, 4, 4, 4]);
     sender.balance = Balance::from(4);
     let new_key_pair = KeyPair::generate();
@@ -501,7 +501,7 @@ fn test_open_account() {
 
 #[test]
 fn test_close_account() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let mut sender = init_local_client_state(vec![2, 4, 4, 4]);
     sender.balance = Balance::from(4);
     let certificate = rt.block_on(sender.close_account()).unwrap();
@@ -527,7 +527,7 @@ fn test_close_account() {
 
 #[test]
 fn test_initiating_valid_transfer_despite_bad_authority() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let mut sender = init_local_client_state_with_bad_authority(vec![4, 4, 4, 4]);
     sender.balance = Balance::from(4);
     let certificate = rt
@@ -552,7 +552,7 @@ fn test_initiating_valid_transfer_despite_bad_authority() {
 
 #[test]
 fn test_initiating_transfer_low_funds() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let mut sender = init_local_client_state(vec![2, 2, 4, 4]);
     sender.balance = Balance::from(2);
     assert!(rt
@@ -569,7 +569,7 @@ fn test_initiating_transfer_low_funds() {
 
 #[test]
 fn test_bidirectional_transfer() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let (mut authority_clients, committee) = init_local_authorities(4);
     let mut client1 = make_client(dbg_account(1), authority_clients.clone(), committee.clone());
     let mut client2 = make_client(dbg_account(2), authority_clients.clone(), committee);
@@ -654,7 +654,7 @@ fn test_bidirectional_transfer() {
 
 #[test]
 fn test_receiving_unconfirmed_transfer() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let (mut authority_clients, committee) = init_local_authorities(4);
     let mut client1 = make_client(dbg_account(1), authority_clients.clone(), committee.clone());
     let mut client2 = make_client(dbg_account(2), authority_clients.clone(), committee);
@@ -702,7 +702,7 @@ fn test_receiving_unconfirmed_transfer() {
 
 #[test]
 fn test_receiving_unconfirmed_transfer_with_lagging_sender_balances() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     let (mut authority_clients, committee) = init_local_authorities(4);
     let mut client0 = make_client(dbg_account(1), authority_clients.clone(), committee.clone());
     let mut client1 = make_client(dbg_account(2), authority_clients.clone(), committee.clone());

--- a/fastpay_core/src/unit_tests/downloader_tests.rs
+++ b/fastpay_core/src/unit_tests/downloader_tests.rs
@@ -29,7 +29,7 @@ impl Requester for LocalRequester {
 
 #[test]
 fn test_local_downloader() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     rt.block_on(async move {
         let requester = LocalRequester::new();
         let (task, mut handle) = Downloader::start(requester, vec![("a", 10), ("d", 11)]);


### PR DESCRIPTION
* Since account ID are unique and we pass around the certificates, it's very easy to remove duplicated cross-shard requests.
* This allows us to re-try failed cross-shard requests (at least network failures for now).
* Drop the TcpStream value (so that we can reconnect) when a cross-shard request just failed.
* Upgrade to tokio 1.12.0
* Upgrade other crates (except rand)