### PR TITLE
Use coconut to support private coins in fastpay

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ ACCOUNT2="`tail -n -1 initial_accounts.txt | awk -F: '{ print $1 }'`"
 # Create derived account
 ACCOUNT3="`./client --committee committee.json --accounts accounts.json open_account --from "$ACCOUNT1"`"
 
-# Create coins into the derived account
-./client --committee committee.json --accounts accounts.json spend_and_create_coins --from "$ACCOUNT2" --to-coins "$ACCOUNT3:55" "$ACCOUNT3:55"
+# Create coins (1 transparent and 1 opaque) into the derived account
+./client --committee committee.json --accounts accounts.json spend_and_create_coins --from "$ACCOUNT2" --to-coins "$ACCOUNT3:50" "($ACCOUNT3:60)"
 
 # Inspect state of derived account
 fgrep '"account_id"':"$ACCOUNT3" accounts.json

--- a/README.md
+++ b/README.md
@@ -19,10 +19,18 @@ rm -f *.json *.txt
 # Create configuration files for 4 authorities with 4 shards each.
 # * Private server states are stored in `server*.json`.
 # * `committee.json` is the public description of the FastPay committee.
-for I in 1 2 3 4
-do
-    ./server --server server"$I".json generate --host 127.0.0.1 --port 9"$I"00 --shards 4 >> committee.json
-done
+# for I in 1 2 3 4
+# do
+#    ./server generate --server server_"$I".json --host 127.0.0.1 --port 9"$I"00 --shards 4 >> committee.json
+# done
+
+# or equivalently:
+./server generate-all --authorities \
+   server_1.json:udp:127.0.0.1:9100:4 \
+   server_2.json:udp:127.0.0.1:9200:4 \
+   server_3.json:udp:127.0.0.1:9300:4 \
+   server_4.json:udp:127.0.0.1:9400:4 \
+--committee committee.json
 
 # Create configuration files for 1000 user accounts.
 # * Private account states are stored in one local wallet `accounts.json`.
@@ -34,7 +42,7 @@ for I in 1 2 3 4
 do
     for J in $(seq 0 3)
     do
-        ./server --server server"$I".json run --shard "$J" --initial-accounts initial_accounts.txt --committee committee.json &
+        ./server run --server server_"$I".json --shard "$J" --initial-accounts initial_accounts.txt --committee committee.json &
     done
  done
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ rm -f *.json *.txt
 # Create configuration files for 4 authorities with 4 shards each.
 # * Private server states are stored in `server*.json`.
 # * `committee.json` is the public description of the FastPay committee.
+
+# echo 'null' > committee.json  # no coconut parameters
 # for I in 1 2 3 4
 # do
 #    ./server generate --server server_"$I".json --host 127.0.0.1 --port 9"$I"00 --shards 4 >> committee.json
 # done
 
-# or equivalently:
+# With coconut trusted setup:
 ./server generate-all --authorities \
    server_1.json:udp:127.0.0.1:9100:4 \
    server_2.json:udp:127.0.0.1:9200:4 \

--- a/coconut/src/issuance.rs
+++ b/coconut/src/issuance.rs
@@ -93,6 +93,16 @@ impl BlindedCoins {
         Self { coins }
     }
 
+    /// Number of blinded coins.
+    pub fn len(&self) -> usize {
+        self.coins.len()
+    }
+
+    /// Whether there is no coin. (Needed for https://rust-lang.github.io/rust-clippy/master/index.html#len_without_is_empty)
+    pub fn is_empty(&self) -> bool {
+        self.coins.is_empty()
+    }
+
     /// Unblinds the coins.
     pub fn unblind(
         &self,

--- a/coconut/src/proof.rs
+++ b/coconut/src/proof.rs
@@ -209,7 +209,6 @@ impl RequestCoinsProof {
         offset: &Scalar,
     ) -> CoconutResult<()> {
         ensure!(sigmas.len() == kappas.len(), CoconutError::MalformedProof);
-        ensure!(sigmas.len() == cms.len(), CoconutError::MalformedProof);
         ensure!(
             sigmas.len() == input_commitments.len(),
             CoconutError::MalformedProof

--- a/coconut/src/proof.rs
+++ b/coconut/src/proof.rs
@@ -44,7 +44,7 @@ impl RequestCoinsProof {
     ) -> Self {
         assert!(parameters.max_attributes() >= 3);
         assert!(public_key.max_attributes() >= 3);
-        assert!(parameters.max_attributes() >= output_attributes.len());
+        assert!(parameters.max_outputs() >= output_attributes.len());
 
         // Compute the witnesses.
         let input_attributes_witnesses: Vec<_> = input_attributes
@@ -226,7 +226,7 @@ impl RequestCoinsProof {
             CoconutError::TooManyAttributes
         );
         ensure!(
-            parameters.max_attributes() >= output_commitments.len(),
+            parameters.max_outputs() >= output_commitments.len(),
             CoconutError::MalformedProof
         );
 

--- a/coconut/src/proof.rs
+++ b/coconut/src/proof.rs
@@ -52,7 +52,7 @@ impl RequestCoinsProof {
             .map(|_| InputAttribute {
                 value: Scalar::random(&mut rng),
                 seed: Scalar::random(&mut rng),
-                id: Scalar::zero(), // Never used, the input id is revealed.
+                key: Scalar::zero(), // Never used, the input key is revealed.
             })
             .collect();
         let output_attributes_witnesses: Vec<_> = output_attributes
@@ -62,8 +62,8 @@ impl RequestCoinsProof {
                 value_blinding_factor: Scalar::random(&mut rng),
                 seed: Scalar::random(&mut rng),
                 seed_blinding_factor: Scalar::random(&mut rng),
-                id: Scalar::random(&mut rng),
-                id_blinding_factor: Scalar::random(&mut rng),
+                key: Scalar::random(&mut rng),
+                key_blinding_factor: Scalar::random(&mut rng),
             })
             .collect();
         let randomness_witnesses =
@@ -85,7 +85,7 @@ impl RequestCoinsProof {
         let cms: Vec<_> = output_attributes_witnesses
             .iter()
             .zip(randomness_witnesses.os.iter())
-            .map(|(x, o)| h0 * x.value + h1 * x.seed + h2 * x.id + parameters.g1 * o)
+            .map(|(x, o)| h0 * x.value + h1 * x.seed + h2 * x.key + parameters.g1 * o)
             .collect();
 
         let cs: Vec<_> = output_attributes_witnesses
@@ -95,7 +95,7 @@ impl RequestCoinsProof {
                 (
                     h * x.value + parameters.g1 * x.value_blinding_factor,
                     h * x.seed + parameters.g1 * x.seed_blinding_factor,
-                    h * x.id + parameters.g1 * x.id_blinding_factor,
+                    h * x.key + parameters.g1 * x.key_blinding_factor,
                 )
             })
             .collect();
@@ -136,7 +136,7 @@ impl RequestCoinsProof {
             .map(|(attribute, witness)| InputAttribute {
                 value: witness.value - challenge * attribute.value,
                 seed: witness.seed - challenge * attribute.seed,
-                id: Scalar::zero(), // Never user, the input id is revealed.
+                key: Scalar::zero(), // Never user, the input key is revealed.
             })
             .collect();
 
@@ -150,9 +150,9 @@ impl RequestCoinsProof {
                 seed: witness.seed - challenge * attribute.seed,
                 seed_blinding_factor: witness.seed_blinding_factor
                     - challenge * attribute.seed_blinding_factor,
-                id: witness.id - challenge * attribute.id,
-                id_blinding_factor: witness.id_blinding_factor
-                    - challenge * attribute.id_blinding_factor,
+                key: witness.key - challenge * attribute.key,
+                key_blinding_factor: witness.key_blinding_factor
+                    - challenge * attribute.key_blinding_factor,
             })
             .collect();
 
@@ -265,7 +265,7 @@ impl RequestCoinsProof {
                 cm * self.challenge
                     + h0 * attribute.value
                     + h1 * attribute.seed
-                    + h2 * attribute.id
+                    + h2 * attribute.key
                     + parameters.g1 * o
             })
             .collect();
@@ -283,8 +283,8 @@ impl RequestCoinsProof {
                         + h * attribute.seed
                         + parameters.g1 * attribute.seed_blinding_factor,
                     part3 * self.challenge
-                        + h * attribute.id
-                        + parameters.g1 * attribute.id_blinding_factor,
+                        + h * attribute.key
+                        + parameters.g1 * attribute.key_blinding_factor,
                 )
             })
             .collect();

--- a/coconut/src/setup.rs
+++ b/coconut/src/setup.rs
@@ -33,7 +33,7 @@ pub struct Parameters {
     pub hs: Vec<G1Projective>,
     /// A generator of G2.
     pub g2: G2Projective,
-    // Bulletproofs generators.
+    /// Bulletproofs generators.
     pub bulletproof_gens: BulletproofGens,
 }
 
@@ -56,7 +56,7 @@ impl Parameters {
         self.hs.len()
     }
 
-    /// Return the maximum number of output coins.
+    /// Return the maximum number of output coins per proof.
     pub fn max_outputs(&self) -> usize {
         self.bulletproof_gens.party_capacity
     }

--- a/coconut/src/tests/fixtures.rs
+++ b/coconut/src/tests/fixtures.rs
@@ -43,7 +43,7 @@ pub fn input_attribute1() -> InputAttribute {
     InputAttribute {
         value: Scalar::one(),
         seed: Scalar::from(101),
-        id: Scalar::from(1234),
+        key: Scalar::from(1234),
     }
 }
 
@@ -51,7 +51,7 @@ pub fn input_attribute2() -> InputAttribute {
     InputAttribute {
         value: Scalar::from(3),
         seed: Scalar::from(102),
-        id: Scalar::from(5678),
+        key: Scalar::from(5678),
     }
 }
 
@@ -68,16 +68,16 @@ pub fn output_attributes() -> Vec<OutputAttribute> {
             value_blinding_factor: Scalar::from(10),
             seed: Scalar::from(102),
             seed_blinding_factor: Scalar::from(103),
-            id: Scalar::from(9123),
-            id_blinding_factor: Scalar::from(20),
+            key: Scalar::from(9123),
+            key_blinding_factor: Scalar::from(20),
         },
         OutputAttribute {
             value: Scalar::from(3),
             value_blinding_factor: Scalar::from(30),
             seed: Scalar::from(104),
             seed_blinding_factor: Scalar::from(105),
-            id: Scalar::from(4567),
-            id_blinding_factor: Scalar::from(40),
+            key: Scalar::from(4567),
+            key_blinding_factor: Scalar::from(40),
         },
     ]
 }
@@ -94,7 +94,7 @@ pub fn coin1() -> Coin {
         &keypair().secret,
         &input_attribute1().value,
         &input_attribute1().seed,
-        &input_attribute1().id,
+        &input_attribute1().key,
     )
 }
 
@@ -105,7 +105,7 @@ pub fn coin2() -> Coin {
         &keypair().secret,
         &input_attribute2().value,
         &input_attribute2().seed,
-        &input_attribute2().id,
+        &input_attribute2().key,
     )
 }
 

--- a/coconut/src/tests/issuance_tests.rs
+++ b/coconut/src/tests/issuance_tests.rs
@@ -13,13 +13,13 @@ impl Coin {
         secret: &SecretKey,
         value: &Scalar,
         seed: &Scalar,
-        id: &Scalar,
+        key: &Scalar,
     ) -> Self {
         let h0 = parameters.hs[0];
         let h1 = parameters.hs[1];
         let h2 = parameters.hs[2];
         let o = Scalar::one();
-        let cm = h0 * value + h1 * seed + h2 * id + parameters.g1 * o;
+        let cm = h0 * value + h1 * seed + h2 * key + parameters.g1 * o;
 
         let h = Parameters::hash_to_g1(cm.to_bytes());
 
@@ -27,7 +27,7 @@ impl Coin {
         let y1 = &secret.ys[1];
         let y2 = &secret.ys[2];
 
-        let s = h * (value * y0 + seed * y1 + id * y2 + secret.x);
+        let s = h * (value * y0 + seed * y1 + key * y2 + secret.x);
         Self(h, s)
     }
 }
@@ -42,7 +42,7 @@ fn verify_coin() {
         &keypair().public,
         /* value */ input_attribute1().value,
         /* seed */ input_attribute1().seed,
-        /* id */ input_attribute1().id,
+        /* key */ input_attribute1().key,
     );
     assert!(ok);
 }
@@ -64,7 +64,7 @@ fn issue() {
         &keypair().public,
         /* value */ output_attributes()[0].value,
         /* seed */ output_attributes()[0].seed,
-        /* id */ output_attributes()[0].id,
+        /* key */ output_attributes()[0].key,
     );
     assert!(ok);
 
@@ -73,7 +73,7 @@ fn issue() {
         &keypair().public,
         /* value */ output_attributes()[1].value,
         /* seed */ output_attributes()[1].seed,
-        /* id */ output_attributes()[1].id,
+        /* key */ output_attributes()[1].key,
     );
     assert!(ok);
 }
@@ -90,7 +90,7 @@ fn aggregate_coin() {
                 &key.secret,
                 /* value */ &input_attribute1().value,
                 /* seed */ &input_attribute1().seed,
-                /* id */ &input_attribute1().id,
+                /* key */ &input_attribute1().key,
             );
             (coin, key.index)
         })
@@ -105,7 +105,7 @@ fn aggregate_coin() {
         &aggregated_key(),
         /* value */ input_attribute1().value,
         /* seed */ input_attribute1().seed,
-        /* id */ input_attribute1().id,
+        /* key */ input_attribute1().key,
     );
     assert!(ok);
 }
@@ -122,7 +122,7 @@ fn aggregate_coin_fail() {
                 &key.secret,
                 /* value */ &input_attribute1().value,
                 /* seed */ &input_attribute1().seed,
-                /* id */ &input_attribute1().id,
+                /* key */ &input_attribute1().key,
             );
             (coin, key.index)
         })
@@ -137,7 +137,7 @@ fn aggregate_coin_fail() {
         &aggregated_key(),
         /* value */ input_attribute1().value,
         /* seed */ input_attribute1().seed,
-        /* id */ input_attribute1().id,
+        /* key */ input_attribute1().key,
     );
     assert!(!ok);
 }

--- a/coconut/src/tests/request_tests.rs
+++ b/coconut/src/tests/request_tests.rs
@@ -5,8 +5,8 @@ use crate::fixtures::{input_attributes, keypair, offset, parameters, request};
 
 #[test]
 fn verify_request() {
-    let input_ids = vec![input_attributes()[0].id, input_attributes()[1].id];
+    let input_keys = vec![input_attributes()[0].key, input_attributes()[1].key];
     assert!(request()
-        .verify(&parameters(), &keypair().public, &input_ids, &offset())
+        .verify(&parameters(), &keypair().public, &input_keys, &offset())
         .is_ok());
 }

--- a/fastpay/Cargo.toml
+++ b/fastpay/Cargo.toml
@@ -21,6 +21,7 @@ tempfile = "3.2.0"
 tokio = { version = "1.12.0", features = ["full"] }
 
 fastpay_core = { path = "../fastpay_core" }
+coconut = { path = "../coconut", features = ["with_serde"] }
 
 [[bin]]
 name = "client"

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -102,10 +102,7 @@ impl ClientServerBenchmark {
         for _ in 0..self.committee_size {
             keys.push(KeyPair::generate());
         }
-        let committee = Committee {
-            voting_rights: keys.iter().map(|k| (k.public(), 1)).collect(),
-            total_votes: self.committee_size,
-        };
+        let committee = Committee::make_simple(keys.iter().map(|kp| kp.public()).collect());
 
         // Pick an authority and create one state per shard.
         let key_pair_auth = keys.pop().unwrap();

--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -111,6 +111,7 @@ impl ClientServerBenchmark {
             let state = AuthorityState::new_shard(
                 committee.clone(),
                 key_pair_auth.copy(),
+                None,
                 i as u32,
                 self.num_shards,
             );

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -639,7 +639,11 @@ fn main() {
                 let coins = coins.into_iter().map(|c| c.into()).collect();
                 info!("Starting operation to spend the account and create coins");
                 let time_start = Instant::now();
-                let assets = client_state.spend_and_create_coins(coins).await.unwrap();
+                // TODO: opaque coins
+                let assets = client_state
+                    .spend_and_create_coins(coins, Vec::new())
+                    .await
+                    .unwrap();
                 let time_total = time_start.elapsed().as_micros();
                 info!("Operation confirmed after {} us", time_total);
                 info!("{:?}", assets);

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -387,10 +387,10 @@ impl std::str::FromStr for NewCoin {
     }
 }
 
-impl From<NewCoin> for Coin {
+impl From<NewCoin> for TransparentCoin {
     fn from(new: NewCoin) -> Self {
         use rand::Rng;
-        Coin {
+        TransparentCoin {
             account_id: new.account_id,
             amount: new.amount,
             seed: rand::thread_rng().gen(),

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -5,7 +5,7 @@ use crate::transport::NetworkProtocol;
 use fastpay_core::{
     base_types::*,
     client::AccountClientState,
-    committee::Committee,
+    committee::{CoconutSetup, Committee},
     messages::{Address, Certificate, Operation, Value},
 };
 
@@ -37,6 +37,7 @@ impl AuthorityConfig {
 pub struct AuthorityServerConfig {
     pub authority: AuthorityConfig,
     pub key: KeyPair,
+    pub coconut_key: Option<coconut::KeyPair>,
 }
 
 impl AuthorityServerConfig {
@@ -57,26 +58,34 @@ impl AuthorityServerConfig {
 
 #[derive(Debug, Clone)]
 pub struct CommitteeConfig {
+    pub coconut_setup: Option<CoconutSetup>,
     pub authorities: Vec<AuthorityConfig>,
 }
 
 impl CommitteeConfig {
     pub fn into_committee(self) -> Committee {
-        Committee::new(self.voting_rights())
+        Committee::new(self.voting_rights(), self.coconut_setup)
     }
 
     pub fn read(path: &Path) -> Result<Self, std::io::Error> {
         let file = File::open(path)?;
         let mut reader = BufReader::new(file);
+        let coconut_setup = serde_json::Deserializer::from_reader(&mut reader)
+            .into_iter()
+            .next()
+            .unwrap()
+            .ok();
         let stream = serde_json::Deserializer::from_reader(&mut reader).into_iter();
         Ok(Self {
             authorities: stream.filter_map(Result::ok).collect(),
+            coconut_setup,
         })
     }
 
     pub fn write(&self, path: &Path) -> Result<(), std::io::Error> {
         let file = OpenOptions::new().create(true).write(true).open(path)?;
         let mut writer = BufWriter::new(file);
+        serde_json::to_writer(&mut writer, &self.coconut_setup)?;
         for config in &self.authorities {
             serde_json::to_writer(&mut writer, config)?;
             writer.write_all(b"\n")?;

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -6,7 +6,7 @@ use fastpay_core::{
     base_types::*,
     client::AccountClientState,
     committee::{CoconutSetup, Committee},
-    messages::{Address, Certificate, Operation, Value},
+    messages::{Address, Asset, Certificate, Operation, Value},
 };
 
 use serde::{Deserialize, Serialize};
@@ -108,7 +108,7 @@ pub struct UserAccount {
     pub key_pair: Option<KeyPair>,
     pub next_sequence_number: SequenceNumber,
     pub balance: Balance,
-    pub coins: Vec<Certificate>,
+    pub coins: Vec<Asset>,
     pub sent_certificates: Vec<Certificate>,
     pub received_certificates: Vec<Certificate>,
 }

--- a/fastpay/src/network.rs
+++ b/fastpay/src/network.rs
@@ -7,6 +7,7 @@ use fastpay_core::{authority::*, base_types::*, client::*, error::*, messages::*
 use bytes::Bytes;
 use futures::{channel::mpsc, future::FutureExt, sink::SinkExt, stream::StreamExt};
 use log::*;
+use rand::Rng;
 use std::io;
 use structopt::StructOpt;
 use tokio::time;
@@ -405,15 +406,8 @@ impl AuthorityClient for Client {
         order: CoinCreationOrder,
     ) -> AsyncResult<Vec<Vote>, FastPayError> {
         Box::pin(async move {
-            let shard = AuthorityState::get_shard(
-                self.num_shards,
-                &order
-                    .description
-                    .targets
-                    .first()
-                    .ok_or(FastPayError::InvalidCoinCreationOrder)?
-                    .account_id,
-            ); // TODO: this is arbitrary
+            // TODO: We should not let the client choose the shard.
+            let shard = rand::thread_rng().gen_range(0, self.num_shards);
             self.send_recv_votes_bytes(shard, serialize_coin_creation_order(&order))
                 .await
         })

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -215,6 +215,10 @@ enum ServerCommands {
         /// Path where to write the description of the FastPay committee
         #[structopt(long)]
         committee: PathBuf,
+
+        /// Maximum number of opaque coins created at a time
+        #[structopt(long, default_value = "20")]
+        max_output_coins: usize,
     },
 }
 
@@ -291,12 +295,10 @@ fn main() {
         ServerCommands::GenerateAll {
             authorities,
             committee,
+            max_output_coins,
         } => {
             let mut rng = coconut::rand::thread_rng();
-            let parameters = coconut::Parameters::new(
-                3,
-                /* TODO: check party capacity for bulletproofs */ authorities.len(),
-            );
+            let parameters = coconut::Parameters::new(3, max_output_coins);
             let threshold = (2 * authorities.len() + 1) / 3;
             let (verification_key, key_pairs) =
                 coconut::KeyPair::ttp(&mut rng, &parameters, threshold, authorities.len());

--- a/fastpay/src/transport.rs
+++ b/fastpay/src/transport.rs
@@ -20,7 +20,7 @@ pub const DEFAULT_MAX_DATAGRAM_SIZE: &str = "65507";
 
 // Supported transport protocols.
 arg_enum! {
-    #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+    #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
     pub enum NetworkProtocol {
         Udp,
         Tcp,

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -10,6 +10,7 @@ bcs = "0.1.3"
 bincode = "1.3.3"
 coconut = { version = "0.1.0", path = "../coconut", features = ["with_serde"] }
 failure = "0.1.8"
+ff = "0.11.0"
 futures = "0.3.17"
 generic-array = { version = "0.14.4", features = ["serde"] }
 hex = "0.4.3"

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 bcs = "0.1.3"
 bincode = "1.3.3"
+coconut = { version = "0.1.0", path = "../coconut", features = ["with_serde"] }
 failure = "0.1.8"
 futures = "0.3.17"
 generic-array = { version = "0.14.4", features = ["serde"] }
@@ -26,6 +27,16 @@ structopt = "0.3.23"
 similar-asserts = "1.1.0"
 serde-reflection = "0.3.5"
 serde_yaml = "0.8.21"
+coconut = { version = "0.1.0", path = "../coconut", features = ["with_equality"] }
+bulletproofs = { version = "0.1.0", path = "../bulletproofs", features = ["with_equality"] }
+merlin = "2"
+ff = "0.11.0"
+
+[dependencies.bls12_381]
+version = "0.6.0"
+git = "https://github.com/matbd/bls12_381"
+branch = "serde"
+features = ["experimental"]
 
 [[example]]
 name = "generate-format"

--- a/fastpay_core/src/account.rs
+++ b/fastpay_core/src/account.rs
@@ -81,7 +81,7 @@ impl AccountState {
                     value:
                         OpaqueCoin {
                             id,
-                            value,
+                            amount,
                             public_seed,
                             ..
                         },
@@ -90,7 +90,7 @@ impl AccountState {
                     // Seeds must be distinct.
                     fp_ensure!(!z_seeds.contains(public_seed), FastPayError::InvalidCoin);
                     z_seeds.insert(*public_seed);
-                    (id, *value)
+                    (id, *amount)
                 }
             };
             // Verify linked account.

--- a/fastpay_core/src/account.rs
+++ b/fastpay_core/src/account.rs
@@ -80,7 +80,7 @@ impl AccountState {
                 Asset::OpaqueCoin {
                     value:
                         OpaqueCoin {
-                            id,
+                            account_id,
                             amount,
                             public_seed,
                             ..
@@ -90,7 +90,7 @@ impl AccountState {
                     // Seeds must be distinct.
                     fp_ensure!(!z_seeds.contains(public_seed), FastPayError::InvalidCoin);
                     z_seeds.insert(*public_seed);
-                    (id, *amount)
+                    (account_id, *amount)
                 }
             };
             // Verify linked account.

--- a/fastpay_core/src/account.rs
+++ b/fastpay_core/src/account.rs
@@ -53,29 +53,46 @@ impl AccountState {
         }
     }
 
-    pub(crate) fn verify_linked_coins(
-        id: &AccountId,
-        coins: &[&Value],
+    pub(crate) fn verify_linked_assets(
+        account_id: &AccountId,
+        assets: &[Asset],
     ) -> Result<Amount, FastPayError> {
         let mut total = Amount::zero();
-        let mut seeds = BTreeSet::new();
-        for coin in coins {
-            match coin {
-                Value::Coin(TransparentCoin {
-                    account_id,
-                    amount,
-                    seed,
-                }) => {
-                    // Verify linked account.
-                    fp_ensure!(account_id == id, FastPayError::InvalidCoin);
-                    // Seeds must be distinct.
-                    fp_ensure!(!seeds.contains(seed), FastPayError::InvalidCoin);
-                    // Update source amount and seeds.
-                    total.try_add_assign(*amount)?;
-                    seeds.insert(*seed);
+        let mut t_seeds = BTreeSet::new();
+        let mut z_seeds = BTreeSet::new();
+        for asset in assets {
+            let (id, value) = match asset {
+                Asset::TransparentCoin(certificate) => {
+                    if let Value::Coin(TransparentCoin {
+                        account_id,
+                        amount,
+                        seed,
+                    }) = &certificate.value
+                    {
+                        // Seeds must be distinct.
+                        fp_ensure!(!t_seeds.contains(seed), FastPayError::InvalidCoin);
+                        t_seeds.insert(*seed);
+                        (account_id, *amount)
+                    } else {
+                        continue;
+                    }
                 }
-                _ => fp_bail!(FastPayError::InvalidCoin),
-            }
+                Asset::OpaqueCoin(OpaqueCoin {
+                    id,
+                    value,
+                    public_seed,
+                    ..
+                }) => {
+                    // Seeds must be distinct.
+                    fp_ensure!(!z_seeds.contains(public_seed), FastPayError::InvalidCoin);
+                    z_seeds.insert(*public_seed);
+                    (id, *value)
+                }
+            };
+            // Verify linked account.
+            fp_ensure!(account_id == id, FastPayError::InvalidCoin);
+            // Update source amount.
+            total.try_add_assign(value)?;
         }
         Ok(total)
     }
@@ -84,7 +101,7 @@ impl AccountState {
     pub(crate) fn validate_operation(
         &self,
         request: Request,
-        assets: &[&Value],
+        assets: &[Asset],
     ) -> Result<Value, FastPayError> {
         let value = match &request.operation {
             Operation::Transfer { amount, .. } => {
@@ -112,9 +129,8 @@ impl AccountState {
                 Value::Lock(request)
             }
             Operation::SpendAndTransfer { amount, .. } => {
-                // Verify source coins.
-                let coin_total = Self::verify_linked_coins(&request.account_id, assets)?;
                 // Verify balance.
+                let coin_total = Self::verify_linked_assets(&request.account_id, assets)?;
                 let public_amount = amount.try_sub(coin_total)?;
                 fp_ensure!(
                     self.balance >= public_amount.into(),

--- a/fastpay_core/src/account.rs
+++ b/fastpay_core/src/account.rs
@@ -61,7 +61,7 @@ impl AccountState {
         let mut seeds = BTreeSet::new();
         for coin in coins {
             match coin {
-                Value::Coin(Coin {
+                Value::Coin(TransparentCoin {
                     account_id,
                     amount,
                     seed,

--- a/fastpay_core/src/account.rs
+++ b/fastpay_core/src/account.rs
@@ -62,7 +62,7 @@ impl AccountState {
         let mut z_seeds = BTreeSet::new();
         for asset in assets {
             let (id, value) = match asset {
-                Asset::TransparentCoin(certificate) => {
+                Asset::TransparentCoin { certificate } => {
                     if let Value::Coin(TransparentCoin {
                         account_id,
                         amount,
@@ -77,12 +77,16 @@ impl AccountState {
                         continue;
                     }
                 }
-                Asset::OpaqueCoin(OpaqueCoin {
-                    id,
-                    value,
-                    public_seed,
+                Asset::OpaqueCoin {
+                    value:
+                        OpaqueCoin {
+                            id,
+                            value,
+                            public_seed,
+                            ..
+                        },
                     ..
-                }) => {
+                } => {
                     // Seeds must be distinct.
                     fp_ensure!(!z_seeds.contains(public_seed), FastPayError::InvalidCoin);
                     z_seeds.insert(*public_seed);

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -18,6 +18,8 @@ pub struct AuthorityState {
     pub committee: Committee,
     /// The signature key pair of the authority.
     pub key_pair: KeyPair,
+    /// The signature key pair of the authority.
+    pub coconut_key_pair: Option<coconut::KeyPair>,
     /// States of FastPay accounts.
     pub accounts: BTreeMap<AccountId, AccountState>,
     /// The latest transaction index of the blockchain that the authority has seen.
@@ -399,11 +401,17 @@ impl Authority for AuthorityState {
 }
 
 impl AuthorityState {
-    pub fn new(committee: Committee, name: AuthorityName, key_pair: KeyPair) -> Self {
+    pub fn new(
+        committee: Committee,
+        name: AuthorityName,
+        key_pair: KeyPair,
+        coconut_key_pair: Option<coconut::KeyPair>,
+    ) -> Self {
         AuthorityState {
             committee,
             name,
             key_pair,
+            coconut_key_pair,
             accounts: BTreeMap::new(),
             last_transaction_index: SequenceNumber::new(),
             shard_id: 0,
@@ -414,6 +422,7 @@ impl AuthorityState {
     pub fn new_shard(
         committee: Committee,
         key_pair: KeyPair,
+        coconut_key_pair: Option<coconut::KeyPair>,
         shard_id: u32,
         number_of_shards: u32,
     ) -> Self {
@@ -421,6 +430,7 @@ impl AuthorityState {
             committee,
             name: key_pair.public(),
             key_pair,
+            coconut_key_pair,
             accounts: BTreeMap::new(),
             last_transaction_index: SequenceNumber::new(),
             shard_id,

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -332,7 +332,7 @@ impl Authority for AuthorityState {
                         );
                         seen.insert(*public_seed);
                         let key = CoconutKey {
-                            id: source.account_id.clone(),
+                            account_id: source.account_id.clone(),
                             public_seed: *public_seed,
                         };
                         keys.push(key.scalar());

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -291,7 +291,9 @@ impl Authority for AuthorityState {
             let mut assets = Vec::new();
             for coin in &source.transparent_coins {
                 coin.check(&self.committee)?;
-                assets.push(Asset::TransparentCoin(coin.clone()));
+                assets.push(Asset::TransparentCoin {
+                    certificate: coin.clone(),
+                });
             }
             let coin_amount = AccountState::verify_linked_assets(&source.account_id, &assets)?;
             source_amount.try_add_assign(coin_amount)?;

--- a/fastpay_core/src/base_types.rs
+++ b/fastpay_core/src/base_types.rs
@@ -548,6 +548,10 @@ impl HashValue {
         value.write(&mut hasher);
         HashValue(hasher.finalize())
     }
+
+    pub fn as_bytes(&self) -> &[u8; 64] {
+        self.0.as_ref().try_into().expect("unexpected size")
+    }
 }
 
 impl Signature {

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -1264,6 +1264,11 @@ where
                         .coconut_setup
                         .as_ref()
                         .expect("Coconut must be configured to use opaque coins");
+                    ensure!(
+                        new_opaque_coins.len() <= setup.parameters.max_outputs(),
+                        "Cannot create more than {} coins at a time in the current setup",
+                        setup.parameters.max_outputs()
+                    );
                     let input_attributes = self
                         .coins
                         .iter()

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -97,13 +97,15 @@ pub trait AccountClient {
     fn create_coins(
         &mut self,
         description: CoinCreationDescription,
+        new_opaque_coins: Vec<(OpaqueCoin, coconut::OutputAttribute)>,
         locked_accounts: Vec<Certificate>,
     ) -> AsyncResult<Vec<Asset>, failure::Error>;
 
     /// Spend a single account and create new coins.
     fn spend_and_create_coins(
         &mut self,
-        new_coins: Vec<TransparentCoin>,
+        new_transparent_coins: Vec<TransparentCoin>,
+        new_opaque_coins: Vec<OpaqueCoin>,
     ) -> AsyncResult<Vec<Asset>, failure::Error>;
 
     /// Spend the account and transfer the value to a receiver.
@@ -827,8 +829,8 @@ where
     async fn execute_coin_creation(
         &mut self,
         order: CoinCreationOrder,
+        new_opaque_coins: Vec<(OpaqueCoin, coconut::OutputAttribute)>,
     ) -> Result<Vec<Asset>, failure::Error> {
-        // TODO: support creation of opaque coins
         let targets = order.description.targets.clone();
         let coin_num = targets.len();
         let committee = self.committee.clone();
@@ -837,6 +839,10 @@ where
                 let order = order.clone();
                 let committee = committee.clone();
                 let targets = targets.clone();
+                let output_attributes = new_opaque_coins
+                    .iter()
+                    .map(|(_, attribute)| attribute.clone())
+                    .collect::<Vec<_>>();
                 Box::pin(async move {
                     let response = client.handle_coin_creation_order(order).await?;
                     fp_ensure!(
@@ -854,13 +860,43 @@ where
                         );
                         vote.check(&committee)?;
                     }
-                    // TODO
-                    Ok(response.votes)
+                    let (index, verified_shares) = match response.blinded_coins {
+                        None => (/* unused */ 0, Vec::new()),
+                        Some(blinded_coins) => {
+                            let setup = committee
+                                .coconut_setup
+                                .as_ref()
+                                .ok_or(FastPayError::ClientErrorWhileProcessingCoinCreationOrder)?;
+                            fp_ensure!(
+                                blinded_coins.len() == output_attributes.len(),
+                                FastPayError::ClientErrorWhileProcessingCoinCreationOrder
+                            );
+                            let (index, public_key) = &setup
+                                .authorities
+                                .get(&name)
+                                .ok_or(FastPayError::ClientErrorWhileProcessingCoinCreationOrder)?;
+                            let shares = blinded_coins.unblind(public_key, &output_attributes);
+                            for (share, attributes) in shares.iter().zip(output_attributes.iter()) {
+                                fp_ensure!(
+                                    share.plain_verify(
+                                        &setup.parameters,
+                                        public_key,
+                                        attributes.value,
+                                        attributes.seed,
+                                        attributes.key
+                                    ),
+                                    FastPayError::ClientErrorWhileProcessingCoinCreationOrder
+                                );
+                            }
+                            (*index, shares)
+                        }
+                    };
+                    Ok((response.votes, index, verified_shares))
                 })
             })
             .await;
-        let vote_vectors = match result {
-            Ok(vectors) => vectors,
+        let responses = match result {
+            Ok(responses) => responses,
             Err(Some(err)) => bail!(
                 "Failed to communicate with a quorum of authorities: {}",
                 err
@@ -873,13 +909,25 @@ where
             .into_iter()
             .map(|coin| SignatureAggregator::new(Value::Coin(coin), &committee))
             .collect::<Vec<_>>();
+        let mut coin_shares = std::iter::repeat_with(Vec::new)
+            .take(new_opaque_coins.len())
+            .collect::<Vec<_>>();
         let mut coins = Vec::new();
-        for vector in vote_vectors {
-            for (i, vote) in vector.into_iter().enumerate() {
+        for (votes, index, shares) in responses {
+            // Votes for transparent coins.
+            for (i, vote) in votes.into_iter().enumerate() {
                 if let Some(certificate) = builders[i].append(vote.authority, vote.signature)? {
                     coins.push(Asset::TransparentCoin { certificate });
                 }
             }
+            // Organize Lagrange shares of opaque coins.
+            for (i, share) in shares.into_iter().enumerate() {
+                coin_shares[i].push((share, index));
+            }
+        }
+        for (shares, (value, _)) in coin_shares.into_iter().zip(new_opaque_coins.into_iter()) {
+            let credential = coconut::Coin::aggregate(&shares);
+            coins.push(Asset::OpaqueCoin { value, credential });
         }
         Ok(coins)
     }
@@ -1116,33 +1164,54 @@ where
     fn create_coins(
         &mut self,
         description: CoinCreationDescription,
+        new_opaque_coins: Vec<(OpaqueCoin, coconut::OutputAttribute)>,
         locks: Vec<Certificate>,
     ) -> AsyncResult<Vec<Asset>, failure::Error> {
         Box::pin(async move {
             let creation_order = CoinCreationOrder { description, locks };
-            let coins = self.execute_coin_creation(creation_order).await?;
+            let coins = self
+                .execute_coin_creation(creation_order, new_opaque_coins)
+                .await?;
             Ok(coins)
         })
     }
 
     fn spend_and_create_coins(
         &mut self,
-        new_coins: Vec<TransparentCoin>, // TODO: support creation of opaque coins
+        new_transparent_coins: Vec<TransparentCoin>,
+        new_opaque_coins: Vec<OpaqueCoin>,
     ) -> AsyncResult<Vec<Asset>, failure::Error> {
         Box::pin(async move {
             let account_balance = self.synchronize_balance().await?;
             let mut amount =
                 Amount::try_from(account_balance.try_add(self.get_coins_value()?.into())?)?;
-            let mut seeds = BTreeSet::new();
-            for coin in &new_coins {
-                ensure!(
-                    !seeds.contains(&coin.seed),
-                    "TransparentCoin seeds must be unique"
-                );
-                seeds.insert(coin.seed);
-                amount
-                    .try_sub_assign(coin.amount)
-                    .map_err(|_| failure::format_err!("Insufficient balance to create coins"))?;
+            // Check description for new transparent coins.
+            {
+                let mut seeds = BTreeSet::new();
+                for coin in &new_transparent_coins {
+                    ensure!(
+                        !seeds.contains(&coin.seed),
+                        "TransparentCoin seeds must be unique"
+                    );
+                    seeds.insert(coin.seed);
+                    amount.try_sub_assign(coin.amount).map_err(|_| {
+                        failure::format_err!("Insufficient balance to create coins")
+                    })?;
+                }
+            }
+            // Check description for new opaque coins.
+            {
+                let mut seeds = BTreeSet::new();
+                for coin in &new_opaque_coins {
+                    ensure!(
+                        !seeds.contains(&coin.public_seed),
+                        "TransparentCoin seeds must be unique"
+                    );
+                    seeds.insert(coin.public_seed);
+                    amount.try_sub_assign(coin.amount).map_err(|_| {
+                        failure::format_err!("Insufficient balance to create coins")
+                    })?;
+                }
             }
             let account_balance = Amount::try_from(account_balance)?;
             let transparent_coins = self
@@ -1184,56 +1253,62 @@ where
                 transparent_coins,
                 opaque_coin_public_seeds,
             };
-            let coconut_request = if opaque_coins.is_empty() {
-                None
-            } else {
-                let setup = self
-                    .committee
-                    .coconut_setup
-                    .as_ref()
-                    .expect("Coconut must be configured to use opaque coins");
-                let input_attributes = self
-                    .coins
-                    .iter()
-                    .filter_map(|asset| match asset {
-                        Asset::OpaqueCoin { value, .. } => Some(value.make_input_attribute()),
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>();
-                let output_attributes = Vec::new();
-                Some(coconut::CoinsRequest::new(
-                    coconut::rand::thread_rng(),
-                    &setup.parameters,
-                    &setup.verification_key,
-                    &opaque_coins,
-                    &input_attributes,
-                    &output_attributes,
-                ))
-            };
+            let (coconut_request, new_opaque_coins_with_attributes) =
+                if opaque_coins.is_empty() && new_opaque_coins.is_empty() {
+                    (None, Vec::new())
+                } else {
+                    let setup = self
+                        .committee
+                        .coconut_setup
+                        .as_ref()
+                        .expect("Coconut must be configured to use opaque coins");
+                    let input_attributes = self
+                        .coins
+                        .iter()
+                        .filter_map(|asset| match asset {
+                            Asset::OpaqueCoin { value, .. } => Some(value.make_input_attribute()),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>();
+                    let mut new_opaque_coins_with_attributes = Vec::new();
+                    let mut output_attributes = Vec::new();
+                    for coin in new_opaque_coins {
+                        let attribute = coin.make_output_attribute();
+                        output_attributes.push(attribute.clone());
+                        new_opaque_coins_with_attributes.push((coin, attribute));
+                    }
+                    let request = coconut::CoinsRequest::new(
+                        coconut::rand::thread_rng(),
+                        &setup.parameters,
+                        &setup.verification_key,
+                        &opaque_coins,
+                        &input_attributes,
+                        &output_attributes,
+                    );
+                    (Some(request), new_opaque_coins_with_attributes)
+                };
             let description = CoinCreationDescription {
                 sources: vec![source],
-                targets: new_coins,
+                targets: new_transparent_coins,
                 coconut_request,
             };
             let description_hash = HashValue::new(&description);
             let lock_certificate = self.spend_unsafe(account_balance, description_hash).await?;
-            self.create_coins(description, vec![lock_certificate]).await
+            self.create_coins(
+                description,
+                new_opaque_coins_with_attributes,
+                vec![lock_certificate],
+            )
+            .await
         })
     }
 
     fn get_coins_value(&self) -> Result<Amount, failure::Error> {
         let mut amount = Amount::from(0);
         for coin in &self.coins {
-            let v = match coin {
-                Asset::OpaqueCoin {
-                    value: OpaqueCoin { value, .. },
-                    ..
-                } => *value,
-                Asset::TransparentCoin { certificate } => certificate
-                    .value
-                    .coin_amount()
-                    .ok_or_else(|| failure::format_err!("Client state contains invalid coins"))?,
-            };
+            let v = coin
+                .value()
+                .map_err(|_| failure::format_err!("Client state contains invalid coins"))?;
             amount.try_add_assign(v)?;
         }
         Ok(amount)

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -100,7 +100,7 @@ pub trait AccountClient {
     /// Spend a single account and create new coins.
     fn spend_and_create_coins(
         &mut self,
-        new_coins: Vec<Coin>,
+        new_coins: Vec<TransparentCoin>,
     ) -> AsyncResult<Vec<Certificate>, failure::Error>;
 
     /// Spend the account and transfer the value to a receiver.
@@ -1121,7 +1121,7 @@ where
 
     fn spend_and_create_coins(
         &mut self,
-        new_coins: Vec<Coin>,
+        new_coins: Vec<TransparentCoin>,
     ) -> AsyncResult<Vec<Certificate>, failure::Error> {
         Box::pin(async move {
             let account_balance = self.synchronize_balance().await?;

--- a/fastpay_core/src/committee.rs
+++ b/fastpay_core/src/committee.rs
@@ -4,7 +4,7 @@
 use super::base_types::*;
 use std::collections::BTreeMap;
 
-#[derive(Eq, PartialEq, Clone, Hash, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Committee {
     pub voting_rights: BTreeMap<AuthorityName, usize>,
     pub total_votes: usize,
@@ -15,6 +15,14 @@ impl Committee {
         let total_votes = voting_rights.iter().fold(0, |sum, (_, votes)| sum + *votes);
         Committee {
             voting_rights,
+            total_votes,
+        }
+    }
+
+    pub fn make_simple(keys: Vec<AuthorityName>) -> Self {
+        let total_votes = keys.len();
+        Committee {
+            voting_rights: keys.into_iter().map(|k| (k, 1)).collect(),
             total_votes,
         }
     }

--- a/fastpay_core/src/committee.rs
+++ b/fastpay_core/src/committee.rs
@@ -16,6 +16,7 @@ pub struct Committee {
 pub struct CoconutSetup {
     pub parameters: coconut::Parameters,
     pub verification_key: coconut::PublicKey,
+    pub authorities: BTreeMap<AuthorityName, (/* lagrange index */ u64, coconut::PublicKey)>,
 }
 
 impl Committee {

--- a/fastpay_core/src/committee.rs
+++ b/fastpay_core/src/committee.rs
@@ -2,20 +2,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::base_types::*;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Committee {
     pub voting_rights: BTreeMap<AuthorityName, usize>,
     pub total_votes: usize,
+    pub coconut_setup: Option<CoconutSetup>,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub struct CoconutSetup {
+    pub parameters: coconut::Parameters,
+    pub verification_key: coconut::PublicKey,
 }
 
 impl Committee {
-    pub fn new(voting_rights: BTreeMap<AuthorityName, usize>) -> Self {
+    pub fn new(
+        voting_rights: BTreeMap<AuthorityName, usize>,
+        coconut_setup: Option<CoconutSetup>,
+    ) -> Self {
         let total_votes = voting_rights.iter().fold(0, |sum, (_, votes)| sum + *votes);
         Committee {
             voting_rights,
             total_votes,
+            coconut_setup,
         }
     }
 
@@ -24,6 +36,7 @@ impl Committee {
         Committee {
             voting_rights: keys.into_iter().map(|k| (k, 1)).collect(),
             total_votes,
+            coconut_setup: None,
         }
     }
 

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -90,6 +90,8 @@ pub enum FastPayError {
     InvalidNewAccountId(AccountId),
     #[fail(display = "Invalid coin.")]
     InvalidCoin,
+    #[fail(display = "Invalid asset information.")]
+    InvalidAsset,
 
     // Other server-side errors
     #[fail(display = "No certificate for this account and sequence number")]

--- a/fastpay_core/src/generate_format.rs
+++ b/fastpay_core/src/generate_format.rs
@@ -7,6 +7,32 @@ use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
 use std::{fs::File, io::Write};
 use structopt::{clap::arg_enum, StructOpt};
 
+fn make_range_proof() -> bulletproofs::RangeProof {
+    use bulletproofs::*;
+    use coconut::rand::{self, Rng as _};
+    use ff::Field as _;
+    use merlin::Transcript;
+
+    let m = 1;
+    let n = 32;
+    let max_bitsize = 64;
+    let max_parties = 8;
+    let pc_gens = PedersenGens::default();
+    let bp_gens = BulletproofGens::new(max_bitsize, max_parties);
+
+    let mut rng = rand::thread_rng();
+
+    let (min, max) = (0u64, ((1u128 << n) - 1) as u64);
+    let values: Vec<u64> = (0..m).map(|_| rng.gen_range(min..max)).collect();
+    let blindings: Vec<Scalar> = (0..m).map(|_| Scalar::random(&mut rng)).collect();
+
+    let mut transcript = Transcript::new(b"AggregatedRangeProofTest");
+    let (proof, _) =
+        RangeProof::prove_multiple(&bp_gens, &pc_gens, &mut transcript, &values, &blindings, n)
+            .unwrap();
+    proof
+}
+
 fn get_registry() -> Result<Registry> {
     let mut tracer = Tracer::new(
         TracerConfig::default()
@@ -18,10 +44,12 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_value(&mut samples, &G1::generator())?;
     tracer.trace_value(&mut samples, &G2::generator())?;
     tracer.trace_value(&mut samples, &Scalar::zero())?;
+    tracer.trace_value(&mut samples, &make_range_proof())?;
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<messages::Address>(&samples)?;
     tracer.trace_type::<messages::Operation>(&samples)?;
     tracer.trace_type::<messages::Value>(&samples)?;
+    tracer.trace_type::<messages::Asset>(&samples)?;
     tracer.trace_type::<messages::CrossShardRequest>(&samples)?;
     tracer.trace_type::<error::FastPayError>(&samples)?;
     tracer.trace_type::<serialize::SerializedMessage>(&samples)?;

--- a/fastpay_core/src/generate_format.rs
+++ b/fastpay_core/src/generate_format.rs
@@ -1,17 +1,23 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 // SPDX-License-Identifier: Apache-2.0
 
+use bls12_381::{G1Projective as G1, G2Projective as G2, Scalar};
 use fastpay_core::{error, messages, serialize};
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
 use std::{fs::File, io::Write};
 use structopt::{clap::arg_enum, StructOpt};
 
 fn get_registry() -> Result<Registry> {
-    let mut tracer = Tracer::new(TracerConfig::default());
-    let samples = Samples::new();
+    let mut tracer = Tracer::new(
+        TracerConfig::default()
+            .record_samples_for_newtype_structs(true)
+            .record_samples_for_tuple_structs(true),
+    );
+    let mut samples = Samples::new();
     // 1. Record samples for types with custom deserializers.
-    // tracer.trace_value(&mut samples, ...)?;
-
+    tracer.trace_value(&mut samples, &G1::generator())?;
+    tracer.trace_value(&mut samples, &G2::generator())?;
+    tracer.trace_value(&mut samples, &Scalar::zero())?;
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<messages::Address>(&samples)?;
     tracer.trace_type::<messages::Operation>(&samples)?;

--- a/fastpay_core/src/generate_format.rs
+++ b/fastpay_core/src/generate_format.rs
@@ -16,7 +16,6 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<messages::Address>(&samples)?;
     tracer.trace_type::<messages::Operation>(&samples)?;
     tracer.trace_type::<messages::Value>(&samples)?;
-    tracer.trace_type::<messages::Coin>(&samples)?;
     tracer.trace_type::<messages::CrossShardRequest>(&samples)?;
     tracer.trace_type::<error::FastPayError>(&samples)?;
     tracer.trace_type::<serialize::SerializedMessage>(&samples)?;

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -161,6 +161,16 @@ pub struct CoinCreationOrder {
     pub locks: Vec<Certificate>,
 }
 
+/// The response to a CoinCreationOrder
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub struct CoinCreationResponse {
+    /// Votes to create transparent coins.
+    pub votes: Vec<Vote>,
+    /// Blinded shares to create opaque coins.
+    pub blinded_coins: Option<coconut::BlindedCoins>,
+}
+
 /// A vote on a statement from an authority.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Eq, PartialEq))]

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -84,9 +84,8 @@ pub struct RequestOrder {
 }
 
 /// A transparent coin linked a given account.
-// TODO: This could be an enum to allow several types of coins.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
-pub struct Coin {
+pub struct TransparentCoin {
     pub account_id: AccountId,
     pub amount: Amount,
     pub seed: u128,
@@ -98,7 +97,7 @@ pub struct Coin {
 pub enum Value {
     Lock(Request),
     Confirm(Request),
-    Coin(Coin),
+    Coin(TransparentCoin),
 }
 
 /// The balance of an account plus linked coins to be used in a coin creation description.
@@ -117,7 +116,7 @@ pub struct CoinCreationDescription {
     /// The sources to be used for coin creation.
     pub sources: Vec<CoinCreationSource>,
     /// The coins to be created.
-    pub targets: Vec<Coin>,
+    pub targets: Vec<TransparentCoin>,
 }
 
 /// Same as RequestOrder but meant to create coins.

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -91,7 +91,7 @@ pub enum Asset {
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct OpaqueCoin {
     /// The owner's account
-    pub id: AccountId,
+    pub account_id: AccountId,
     /// Unique number to distinguish coins inside an account.
     pub public_seed: u128,
     /// Random seed to make sure that the value stay confidential after spending the coin.
@@ -241,7 +241,7 @@ impl From<Certificate> for Asset {
 #[derive(Serialize, Deserialize)]
 pub(crate) struct CoconutKey {
     /// Owner account
-    pub(crate) id: AccountId,
+    pub(crate) account_id: AccountId,
     /// Number used to differentiate coins in the account.
     pub(crate) public_seed: u128,
 }
@@ -256,7 +256,7 @@ impl CoconutKey {
 impl OpaqueCoin {
     pub fn make_input_attribute(&self) -> coconut::InputAttribute {
         let key = CoconutKey {
-            id: self.id.clone(),
+            account_id: self.account_id.clone(),
             public_seed: self.public_seed,
         };
         let value = u64::from(self.amount);
@@ -298,9 +298,9 @@ impl Asset {
                 _ => Err(FastPayError::InvalidAsset),
             },
             Asset::OpaqueCoin {
-                value: OpaqueCoin { id, .. },
+                value: OpaqueCoin { account_id, .. },
                 ..
-            } => Ok(id),
+            } => Ok(account_id),
         }
     }
 

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -254,7 +254,7 @@ impl OpaqueCoin {
             0,
         ]);
         coconut::InputAttribute {
-            id: key.scalar(),
+            key: key.scalar(),
             value: value.into(),
             seed,
         }
@@ -304,8 +304,8 @@ impl Asset {
                         &setup.parameters,
                         &setup.verification_key,
                         attribute.value,
-                        attribute.id,
-                        attribute.seed
+                        attribute.seed,
+                        attribute.key
                     ),
                     FastPayError::InvalidAsset
                 );

--- a/fastpay_core/src/messages.rs
+++ b/fastpay_core/src/messages.rs
@@ -73,6 +73,30 @@ pub struct RequestValue {
     pub limited_to: Option<AuthorityName>,
 }
 
+/// A certified asset that we own.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub enum Asset {
+    TransparentCoin(Certificate),
+    OpaqueCoin(OpaqueCoin),
+}
+
+/// An opaque coin as seen by its owner (or creator).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub struct OpaqueCoin {
+    /// The owner's account
+    pub id: AccountId,
+    /// Unique number to distinguish coins inside an account.
+    pub public_seed: u128,
+    /// Random seed to make sure that the value stay confidential after spending the coin.
+    pub private_seed: u128,
+    /// Value of the coin.
+    pub value: Amount,
+    /// The opaque coin itself.
+    pub coin: coconut::Coin,
+}
+
 /// An authenticated request plus additional certified assets.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Eq, PartialEq))]
@@ -80,7 +104,7 @@ pub struct RequestOrder {
     pub value: RequestValue,
     pub owner: AccountOwner,
     pub signature: Signature,
-    pub assets: Vec<Certificate>,
+    pub assets: Vec<Asset>,
 }
 
 /// A transparent coin linked a given account.
@@ -104,9 +128,14 @@ pub enum Value {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct CoinCreationSource {
+    /// The account being spent
     pub account_id: AccountId,
+    /// The recorded balance
     pub account_balance: Amount,
-    pub coins: Vec<Certificate>,
+    /// Known transparent coins
+    pub transparent_coins: Vec<Certificate>,
+    /// Public seeds for the coins in the coconut creation request.
+    pub opaque_coin_public_seeds: Vec<u128>,
 }
 
 /// Instructions to create a number of coins during a CoinCreationOrder.
@@ -115,8 +144,10 @@ pub struct CoinCreationSource {
 pub struct CoinCreationDescription {
     /// The sources to be used for coin creation.
     pub sources: Vec<CoinCreationSource>,
-    /// The coins to be created.
+    /// Transparent coins to be created.
     pub targets: Vec<TransparentCoin>,
+    /// Request to consume opaque coins and create new (blinded) ones under ZK, if needed.
+    pub coconut_request: Option<coconut::CoinsRequest>,
 }
 
 /// Same as RequestOrder but meant to create coins.
@@ -139,7 +170,8 @@ pub struct Vote {
     pub signature: Signature,
 }
 
-/// A certified statement from the committee.
+/// A certified statement from the committee. Note: Opaque coins have no external
+/// signatures and are authenticated at a lower level.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct Certificate {
@@ -183,6 +215,104 @@ pub struct AccountInfoResponse {
 pub enum CrossShardRequest {
     UpdateRecipient { certificate: Certificate },
     DestroyAccount { account_id: AccountId },
+}
+
+#[cfg(test)]
+impl From<Certificate> for Asset {
+    fn from(certificate: Certificate) -> Self {
+        Self::TransparentCoin(certificate)
+    }
+}
+
+/// The component of the "key" public attribute of an opaque coin.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct CoconutKey {
+    /// Owner account
+    pub(crate) id: AccountId,
+    /// Number used to differentiate coins in the account.
+    pub(crate) public_seed: u128,
+}
+
+impl CoconutKey {
+    pub(crate) fn scalar(&self) -> bls12_381::Scalar {
+        let hash = HashValue::new(self);
+        bls12_381::Scalar::from_bytes_wide(hash.as_bytes())
+    }
+}
+
+impl OpaqueCoin {
+    pub fn make_input_attribute(&self) -> coconut::InputAttribute {
+        let key = CoconutKey {
+            id: self.id.clone(),
+            public_seed: self.public_seed,
+        };
+        let value = u64::from(self.value);
+        let seed = bls12_381::Scalar::from_raw([
+            self.private_seed as u64,
+            (self.private_seed >> 64) as u64,
+            0,
+            0,
+        ]);
+        coconut::InputAttribute {
+            id: key.scalar(),
+            value: value.into(),
+            seed,
+        }
+    }
+}
+
+impl Asset {
+    pub fn account_id(&self) -> Result<&AccountId, FastPayError> {
+        match self {
+            Asset::TransparentCoin(certificate) => match &certificate.value {
+                Value::Coin(coin) => Ok(&coin.account_id),
+                _ => Err(FastPayError::InvalidAsset),
+            },
+            Asset::OpaqueCoin(OpaqueCoin { id, .. }) => Ok(id),
+        }
+    }
+
+    pub fn value(&self) -> Result<Amount, FastPayError> {
+        match self {
+            Asset::TransparentCoin(certificate) => match &certificate.value {
+                Value::Coin(coin) => Ok(coin.amount),
+                _ => Err(FastPayError::InvalidAsset),
+            },
+            Asset::OpaqueCoin(OpaqueCoin { value, .. }) => Ok(*value),
+        }
+    }
+
+    pub fn check(&self, committee: &Committee) -> Result<(), FastPayError> {
+        match self {
+            Asset::TransparentCoin(certificate) => {
+                let value = certificate.check(committee)?;
+                fp_ensure!(
+                    matches!(value, Value::Coin { .. }),
+                    FastPayError::InvalidAsset
+                );
+            }
+            Asset::OpaqueCoin(opaque_coin) => {
+                let setup = match &committee.coconut_setup {
+                    Some(setup) => setup,
+                    None => {
+                        return Err(FastPayError::InvalidAsset);
+                    }
+                };
+                let attribute = opaque_coin.make_input_attribute();
+                fp_ensure!(
+                    opaque_coin.coin.plain_verify(
+                        &setup.parameters,
+                        &setup.verification_key,
+                        attribute.value,
+                        attribute.id,
+                        attribute.seed
+                    ),
+                    FastPayError::InvalidAsset
+                );
+            }
+        }
+        Ok(())
+    }
 }
 
 impl Operation {
@@ -297,7 +427,7 @@ impl From<Request> for RequestValue {
 }
 
 impl RequestOrder {
-    pub fn new(value: RequestValue, secret: &KeyPair, assets: Vec<Certificate>) -> Self {
+    pub fn new(value: RequestValue, secret: &KeyPair, assets: Vec<Asset>) -> Self {
         let signature = Signature::new(&value, secret);
         Self {
             value,
@@ -423,4 +553,5 @@ impl ConfirmationOrder {
 
 impl BcsSignable for RequestValue {}
 impl BcsSignable for Value {}
+impl BcsSignable for CoconutKey {}
 impl BcsSignable for CoinCreationDescription {}

--- a/fastpay_core/src/serialize.rs
+++ b/fastpay_core/src/serialize.rs
@@ -20,8 +20,8 @@ pub enum SerializedMessage {
     InfoQuery(Box<AccountInfoQuery>),
     // Outbound
     Vote(Box<Vote>),
-    Votes(Vec<Vote>),
     InfoResponse(Box<AccountInfoResponse>),
+    CoinCreationResponse(Box<CoinCreationResponse>),
     Error(Box<FastPayError>),
     // Internal to an authority
     CrossShardRequest(Box<CrossShardRequest>),
@@ -39,8 +39,8 @@ enum ShallowSerializedMessage<'a> {
     InfoQuery(&'a AccountInfoQuery),
     // Outbound
     Vote(&'a Vote),
-    Votes(&'a [Vote]),
     InfoResponse(&'a AccountInfoResponse),
+    CoinCreationResponse(&'a CoinCreationResponse),
     Error(&'a FastPayError),
     // Internal to an authority
     CrossShardRequest(&'a CrossShardRequest),
@@ -116,8 +116,8 @@ pub fn serialize_coin_creation_order(value: &CoinCreationOrder) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::CoinCreationOrder(value))
 }
 
-pub fn serialize_votes(value: &[Vote]) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::Votes(value))
+pub fn serialize_coin_creation_response(value: &CoinCreationResponse) -> Vec<u8> {
+    serialize(&ShallowSerializedMessage::CoinCreationResponse(value))
 }
 
 pub fn serialize_vote(value: &Vote) -> Vec<u8> {

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -1011,8 +1011,8 @@ fn init_state() -> AuthorityState {
     let name = key_pair.public();
     let mut authorities = BTreeMap::new();
     authorities.insert(name, /* voting right */ 1);
-    let committee = Committee::new(authorities);
-    AuthorityState::new(committee, name, key_pair)
+    let committee = Committee::new(authorities, None);
+    AuthorityState::new(committee, name, key_pair, None)
 }
 
 fn init_state_with_accounts<I: IntoIterator<Item = (AccountId, AccountOwner, Balance)>>(

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -471,7 +471,7 @@ fn test_handle_confirmation_order_inactive_sender_ok() {
 #[test]
 fn test_handle_coin_creation_order_ok() {
     let mut state = init_state_with_accounts(Vec::new());
-    let coins = vec![
+    let transparent_coins = vec![
         make_certificate(
             &state,
             Value::Coin(TransparentCoin {
@@ -492,7 +492,8 @@ fn test_handle_coin_creation_order_ok() {
     let sources = vec![CoinCreationSource {
         account_id: dbg_account(1),
         account_balance: Amount::from(5),
-        coins,
+        transparent_coins,
+        opaque_coin_public_seeds: Vec::new(),
     }];
     let targets = vec![
         TransparentCoin {
@@ -509,6 +510,7 @@ fn test_handle_coin_creation_order_ok() {
     let description = CoinCreationDescription {
         sources,
         targets: targets.clone(),
+        coconut_request: None,
     };
     let description_hash = HashValue::new(&description);
     let locks = vec![make_certificate(
@@ -547,7 +549,8 @@ fn test_handle_coin_creation_order_no_source_coin_ok() {
     let sources = vec![CoinCreationSource {
         account_id: dbg_account(1),
         account_balance: Amount::from(15),
-        coins: Vec::new(),
+        transparent_coins: Vec::new(),
+        opaque_coin_public_seeds: Vec::new(),
     }];
     let targets = vec![
         TransparentCoin {
@@ -564,6 +567,7 @@ fn test_handle_coin_creation_order_no_source_coin_ok() {
     let description = CoinCreationDescription {
         sources,
         targets: targets.clone(),
+        coconut_request: None,
     };
     let description_hash = HashValue::new(&description);
     let locks = vec![make_certificate(
@@ -602,7 +606,8 @@ fn test_handle_coin_creation_order_empty_target_coin() {
     let sources = vec![CoinCreationSource {
         account_id: dbg_account(1),
         account_balance: Amount::from(15),
-        coins: Vec::new(),
+        transparent_coins: Vec::new(),
+        opaque_coin_public_seeds: Vec::new(),
     }];
     let targets = vec![
         TransparentCoin {
@@ -621,7 +626,11 @@ fn test_handle_coin_creation_order_empty_target_coin() {
             seed: 3,
         },
     ];
-    let description = CoinCreationDescription { sources, targets };
+    let description = CoinCreationDescription {
+        sources,
+        targets,
+        coconut_request: None,
+    };
     let description_hash = HashValue::new(&description);
     let locks = vec![make_certificate(
         &state,
@@ -643,7 +652,7 @@ fn test_handle_coin_creation_order_empty_target_coin() {
 #[test]
 fn test_handle_coin_creation_order_insufficient_funds() {
     let mut state = init_state_with_accounts(Vec::new());
-    let coins = vec![
+    let transparent_coins = vec![
         make_certificate(
             &state,
             Value::Coin(TransparentCoin {
@@ -664,7 +673,8 @@ fn test_handle_coin_creation_order_insufficient_funds() {
     let sources = vec![CoinCreationSource {
         account_id: dbg_account(1),
         account_balance: Amount::from(5),
-        coins,
+        transparent_coins,
+        opaque_coin_public_seeds: Vec::new(),
     }];
     let targets = vec![
         TransparentCoin {
@@ -678,7 +688,11 @@ fn test_handle_coin_creation_order_insufficient_funds() {
             seed: 2,
         },
     ];
-    let description = CoinCreationDescription { sources, targets };
+    let description = CoinCreationDescription {
+        sources,
+        targets,
+        coconut_request: None,
+    };
     let description_hash = HashValue::new(&description);
     let locks = vec![make_certificate(
         &state,
@@ -700,7 +714,7 @@ fn test_handle_coin_creation_order_insufficient_funds() {
 #[test]
 fn test_handle_coin_creation_order_replayed_seed() {
     let mut state = init_state_with_accounts(Vec::new());
-    let coins = vec![
+    let transparent_coins = vec![
         make_certificate(
             &state,
             Value::Coin(TransparentCoin {
@@ -721,7 +735,8 @@ fn test_handle_coin_creation_order_replayed_seed() {
     let sources = vec![CoinCreationSource {
         account_id: dbg_account(1),
         account_balance: Amount::from(5),
-        coins,
+        transparent_coins,
+        opaque_coin_public_seeds: Vec::new(),
     }];
     let targets = vec![
         TransparentCoin {
@@ -735,7 +750,11 @@ fn test_handle_coin_creation_order_replayed_seed() {
             seed: 2,
         },
     ];
-    let description = CoinCreationDescription { sources, targets };
+    let description = CoinCreationDescription {
+        sources,
+        targets,
+        coconut_request: None,
+    };
     let description_hash = HashValue::new(&description);
     let locks = vec![make_certificate(
         &state,
@@ -757,7 +776,7 @@ fn test_handle_coin_creation_order_replayed_seed() {
 #[test]
 fn test_handle_coin_creation_order_incorrect_source() {
     let mut state = init_state_with_accounts(Vec::new());
-    let coins = vec![
+    let transparent_coins = vec![
         make_certificate(
             &state,
             Value::Coin(TransparentCoin {
@@ -778,7 +797,8 @@ fn test_handle_coin_creation_order_incorrect_source() {
     let sources = vec![CoinCreationSource {
         account_id: dbg_account(1),
         account_balance: Amount::from(5),
-        coins,
+        transparent_coins,
+        opaque_coin_public_seeds: Vec::new(),
     }];
     let targets = vec![
         TransparentCoin {
@@ -792,7 +812,11 @@ fn test_handle_coin_creation_order_incorrect_source() {
             seed: 2,
         },
     ];
-    let description = CoinCreationDescription { sources, targets };
+    let description = CoinCreationDescription {
+        sources,
+        targets,
+        coconut_request: None,
+    };
     let description_hash = HashValue::new(&description);
     let locks = vec![make_certificate(
         &state,
@@ -814,7 +838,7 @@ fn test_handle_coin_creation_order_incorrect_source() {
 #[test]
 fn test_handle_coin_creation_order_repeated_source() {
     let mut state = init_state_with_accounts(Vec::new());
-    let coins = vec![
+    let transparent_coins = vec![
         make_certificate(
             &state,
             Value::Coin(TransparentCoin {
@@ -835,7 +859,8 @@ fn test_handle_coin_creation_order_repeated_source() {
     let source = CoinCreationSource {
         account_id: dbg_account(1),
         account_balance: Amount::from(5),
-        coins,
+        transparent_coins,
+        opaque_coin_public_seeds: Vec::new(),
     };
     let sources = vec![source.clone(), source];
     let targets = vec![
@@ -850,7 +875,11 @@ fn test_handle_coin_creation_order_repeated_source() {
             seed: 2,
         },
     ];
-    let description = CoinCreationDescription { sources, targets };
+    let description = CoinCreationDescription {
+        sources,
+        targets,
+        coconut_request: None,
+    };
     let description_hash = HashValue::new(&description);
     let locks = vec![make_certificate(
         &state,
@@ -872,7 +901,7 @@ fn test_handle_coin_creation_order_repeated_source() {
 #[test]
 fn test_handle_coin_creation_order_invalid_balance() {
     let mut state = init_state_with_accounts(Vec::new());
-    let coins = vec![
+    let transparent_coins = vec![
         make_certificate(
             &state,
             Value::Coin(TransparentCoin {
@@ -893,7 +922,8 @@ fn test_handle_coin_creation_order_invalid_balance() {
     let sources = vec![CoinCreationSource {
         account_id: dbg_account(1),
         account_balance: Amount::from(6),
-        coins,
+        transparent_coins,
+        opaque_coin_public_seeds: Vec::new(),
     }];
     let targets = vec![
         TransparentCoin {
@@ -907,7 +937,11 @@ fn test_handle_coin_creation_order_invalid_balance() {
             seed: 2,
         },
     ];
-    let description = CoinCreationDescription { sources, targets };
+    let description = CoinCreationDescription {
+        sources,
+        targets,
+        coconut_request: None,
+    };
     let description_hash = HashValue::new(&description);
     let locks = vec![make_certificate(
         &state,

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -525,9 +525,11 @@ fn test_handle_coin_creation_order_ok() {
         }),
     )];
 
-    let (votes, continuations) = state
+    let (response, continuations) = state
         .handle_coin_creation_order(CoinCreationOrder { locks, description })
         .unwrap();
+    assert_eq!(response.blinded_coins, None);
+    let votes = response.votes;
     assert_eq!(votes.len(), 2);
     for i in 0..2 {
         assert!(matches!(&votes[i].value, Value::Coin(c) if c == &targets[i]));
@@ -582,9 +584,11 @@ fn test_handle_coin_creation_order_no_source_coin_ok() {
         }),
     )];
 
-    let (votes, continuations) = state
+    let (response, continuations) = state
         .handle_coin_creation_order(CoinCreationOrder { locks, description })
         .unwrap();
+    assert_eq!(response.blinded_coins, None);
+    let votes = response.votes;
     assert_eq!(votes.len(), 2);
     for i in 0..2 {
         assert!(matches!(&votes[i].value, Value::Coin(c) if c == &targets[i]));

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -474,7 +474,7 @@ fn test_handle_coin_creation_order_ok() {
     let coins = vec![
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(1),
                 amount: Amount::from(3),
                 seed: 1,
@@ -482,7 +482,7 @@ fn test_handle_coin_creation_order_ok() {
         ),
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(1),
                 amount: Amount::from(7),
                 seed: 2,
@@ -495,12 +495,12 @@ fn test_handle_coin_creation_order_ok() {
         coins,
     }];
     let targets = vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(8),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(3),
             amount: Amount::from(7),
             seed: 2,
@@ -550,12 +550,12 @@ fn test_handle_coin_creation_order_no_source_coin_ok() {
         coins: Vec::new(),
     }];
     let targets = vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(8),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(3),
             amount: Amount::from(7),
             seed: 2,
@@ -605,17 +605,17 @@ fn test_handle_coin_creation_order_empty_target_coin() {
         coins: Vec::new(),
     }];
     let targets = vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(8),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(3),
             amount: Amount::from(7),
             seed: 2,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(0),
             seed: 3,
@@ -646,7 +646,7 @@ fn test_handle_coin_creation_order_insufficient_funds() {
     let coins = vec![
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(1),
                 amount: Amount::from(3),
                 seed: 1,
@@ -654,7 +654,7 @@ fn test_handle_coin_creation_order_insufficient_funds() {
         ),
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(1),
                 amount: Amount::from(7),
                 seed: 2,
@@ -667,12 +667,12 @@ fn test_handle_coin_creation_order_insufficient_funds() {
         coins,
     }];
     let targets = vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(8),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(3),
             amount: Amount::from(8),
             seed: 2,
@@ -703,7 +703,7 @@ fn test_handle_coin_creation_order_replayed_seed() {
     let coins = vec![
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(1),
                 amount: Amount::from(3),
                 seed: 1,
@@ -711,7 +711,7 @@ fn test_handle_coin_creation_order_replayed_seed() {
         ),
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(1),
                 amount: Amount::from(7),
                 seed: 1,
@@ -724,12 +724,12 @@ fn test_handle_coin_creation_order_replayed_seed() {
         coins,
     }];
     let targets = vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(7),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(3),
             amount: Amount::from(8),
             seed: 2,
@@ -760,7 +760,7 @@ fn test_handle_coin_creation_order_incorrect_source() {
     let coins = vec![
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(1),
                 amount: Amount::from(3),
                 seed: 1,
@@ -768,7 +768,7 @@ fn test_handle_coin_creation_order_incorrect_source() {
         ),
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(2),
                 amount: Amount::from(7),
                 seed: 2,
@@ -781,12 +781,12 @@ fn test_handle_coin_creation_order_incorrect_source() {
         coins,
     }];
     let targets = vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(7),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(3),
             amount: Amount::from(8),
             seed: 2,
@@ -817,7 +817,7 @@ fn test_handle_coin_creation_order_repeated_source() {
     let coins = vec![
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(1),
                 amount: Amount::from(3),
                 seed: 1,
@@ -825,7 +825,7 @@ fn test_handle_coin_creation_order_repeated_source() {
         ),
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(1),
                 amount: Amount::from(7),
                 seed: 2,
@@ -839,12 +839,12 @@ fn test_handle_coin_creation_order_repeated_source() {
     };
     let sources = vec![source.clone(), source];
     let targets = vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(7),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(3),
             amount: Amount::from(8),
             seed: 2,
@@ -875,7 +875,7 @@ fn test_handle_coin_creation_order_invalid_balance() {
     let coins = vec![
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(1),
                 amount: Amount::from(3),
                 seed: 1,
@@ -883,7 +883,7 @@ fn test_handle_coin_creation_order_invalid_balance() {
         ),
         make_certificate(
             &state,
-            Value::Coin(Coin {
+            Value::Coin(TransparentCoin {
                 account_id: dbg_account(1),
                 amount: Amount::from(7),
                 seed: 2,
@@ -896,12 +896,12 @@ fn test_handle_coin_creation_order_invalid_balance() {
         coins,
     }];
     let targets = vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(7),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(3),
             amount: Amount::from(8),
             seed: 2,

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -80,12 +80,12 @@ fn init_local_authorities(
         voting_rights.insert(key_pair.public(), 1);
         key_pairs.push(key_pair);
     }
-    let committee = Committee::new(voting_rights);
+    let committee = Committee::new(voting_rights, None);
 
     let mut clients = HashMap::new();
     for key_pair in key_pairs {
         let name = key_pair.public();
-        let state = AuthorityState::new(committee.clone(), name, key_pair);
+        let state = AuthorityState::new(committee.clone(), name, key_pair, None);
         clients.insert(name, LocalAuthorityClient::new(state));
     }
     (clients, committee)
@@ -106,12 +106,12 @@ fn init_local_authorities_bad_1(
             key_pairs.push(key_pair);
         }
     }
-    let committee = Committee::new(voting_rights);
+    let committee = Committee::new(voting_rights, None);
 
     let mut clients = HashMap::new();
     for key_pair in key_pairs {
         let name = key_pair.public();
-        let state = AuthorityState::new(committee.clone(), name, key_pair);
+        let state = AuthorityState::new(committee.clone(), name, key_pair, None);
         clients.insert(name, LocalAuthorityClient::new(state));
     }
     (clients, committee)

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -406,7 +406,7 @@ fn create_and_transfer_coins(coins: Vec<TransparentCoin>) -> Result<(), failure:
         vec![0; 4],
     );
     // spend account #1 and create coins
-    let assets = rt.block_on(client1.spend_and_create_coins(coins.clone()))?;
+    let assets = rt.block_on(client1.spend_and_create_coins(coins.clone(), Vec::new()))?;
     assert!(client1.lock_certificate.is_some());
     assert_eq!(assets.len(), coins.len());
     // receive coins on account #2

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -44,7 +44,7 @@ impl AuthorityClient for LocalAuthorityClient {
     fn handle_coin_creation_order(
         &mut self,
         order: CoinCreationOrder,
-    ) -> AsyncResult<Vec<Vote>, FastPayError> {
+    ) -> AsyncResult<CoinCreationResponse, FastPayError> {
         let state = self.0.clone();
         Box::pin(async move {
             state

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -412,7 +412,7 @@ fn create_and_transfer_coins(coins: Vec<TransparentCoin>) -> Result<(), failure:
     // receive coins on account #2
     for (i, asset) in assets.into_iter().enumerate() {
         assert!(
-            matches!(&asset, Asset::TransparentCoin(certificate) if certificate.value == Value::Coin(coins[i].clone()))
+            matches!(&asset, Asset::TransparentCoin { certificate } if certificate.value == Value::Coin(coins[i].clone()))
         );
         rt.block_on(client2.receive_asset(asset))?;
     }

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -303,7 +303,7 @@ fn test_transfer_ownership() {
 
 #[test]
 fn test_create_single_coin() {
-    create_and_transfer_coins(vec![Coin {
+    create_and_transfer_coins(vec![TransparentCoin {
         account_id: dbg_account(2),
         amount: Amount::from(3),
         seed: 1,
@@ -314,12 +314,12 @@ fn test_create_single_coin() {
 #[test]
 fn test_create_multiple_coins() {
     create_and_transfer_coins(vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(1),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(2),
             seed: 2,
@@ -331,12 +331,12 @@ fn test_create_multiple_coins() {
 #[test]
 fn test_create_multiple_coins_repeated_seeds() {
     assert!(create_and_transfer_coins(vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(1),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(2),
             seed: 1,
@@ -348,12 +348,12 @@ fn test_create_multiple_coins_repeated_seeds() {
 #[test]
 fn test_create_multiple_coins_wrong_account() {
     assert!(create_and_transfer_coins(vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(1),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(3),
             amount: Amount::from(2),
             seed: 2,
@@ -365,12 +365,12 @@ fn test_create_multiple_coins_wrong_account() {
 #[test]
 fn test_create_multiple_coins_balance_exceeded() {
     assert!(create_and_transfer_coins(vec![
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(2),
             seed: 1,
         },
-        Coin {
+        TransparentCoin {
             account_id: dbg_account(2),
             amount: Amount::from(2),
             seed: 2,
@@ -379,7 +379,7 @@ fn test_create_multiple_coins_balance_exceeded() {
     .is_err());
 }
 
-fn create_and_transfer_coins(coins: Vec<Coin>) -> Result<(), failure::Error> {
+fn create_and_transfer_coins(coins: Vec<TransparentCoin>) -> Result<(), failure::Error> {
     let rt = Runtime::new().unwrap();
     let (mut authority_clients, committee) = init_local_authorities(4);
     let mut client1 = make_client(dbg_account(1), authority_clients.clone(), committee.clone());

--- a/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
+++ b/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
@@ -135,7 +135,7 @@ fn init_contract() -> (FastPaySmartContractState, KeyPair) {
     let name = key_pair.public();
     let mut authorities = BTreeMap::new();
     authorities.insert(name, /* voting right */ 1);
-    let committee = Committee::new(authorities);
+    let committee = Committee::new(authorities, None);
     (FastPaySmartContractState::new(committee), key_pair)
 }
 

--- a/fastpay_core/src/unit_tests/messages_tests.rs
+++ b/fastpay_core/src/unit_tests/messages_tests.rs
@@ -15,7 +15,7 @@ fn test_signed_values() {
 
     authorities.insert(name1, /* voting right */ 1);
     authorities.insert(name2, /* voting right */ 0);
-    let committee = Committee::new(authorities);
+    let committee = Committee::new(authorities, None);
 
     let request = Request {
         account_id: dbg_account(1),
@@ -49,7 +49,7 @@ fn test_certificates() {
     let mut authorities = BTreeMap::new();
     authorities.insert(name1, /* voting right */ 1);
     authorities.insert(name2, /* voting right */ 1);
-    let committee = Committee::new(authorities);
+    let committee = Committee::new(authorities, None);
 
     let request = Request {
         account_id: dbg_account(1),

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -413,7 +413,7 @@ InputAttribute:
         TYPENAME: Scalar
 OpaqueCoin:
   STRUCT:
-    - id:
+    - account_id:
         TYPENAME: AccountId
     - public_seed: U128
     - private_seed: U128

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -49,14 +49,26 @@ Asset:
   ENUM:
     0:
       TransparentCoin:
-        NEWTYPE:
-          TYPENAME: Certificate
+        STRUCT:
+          - certificate:
+              TYPENAME: Certificate
     1:
       OpaqueCoin:
-        NEWTYPE:
-          TYPENAME: OpaqueCoin
+        STRUCT:
+          - value:
+              TYPENAME: OpaqueCoin
+          - credential:
+              TYPENAME: Coin
 Balance:
   NEWTYPESTRUCT: I128
+BlindedCoins:
+  STRUCT:
+    - coins:
+        SEQ:
+          TUPLEARRAY:
+            CONTENT:
+              TYPENAME: G1
+            SIZE: 2
 Certificate:
   STRUCT:
     - value:
@@ -88,6 +100,14 @@ CoinCreationOrder:
     - locks:
         SEQ:
           TYPENAME: Certificate
+CoinCreationResponse:
+  STRUCT:
+    - votes:
+        SEQ:
+          TYPENAME: Vote
+    - blinded_coins:
+        OPTION:
+          TYPENAME: BlindedCoins
 CoinCreationSource:
   STRUCT:
     - account_id:
@@ -399,8 +419,6 @@ OpaqueCoin:
     - private_seed: U128
     - value:
         TYPENAME: Amount
-    - coin:
-        TYPENAME: Coin
 Operation:
   ENUM:
     0:
@@ -577,14 +595,13 @@ SerializedMessage:
         NEWTYPE:
           TYPENAME: Vote
     5:
-      Votes:
-        NEWTYPE:
-          SEQ:
-            TYPENAME: Vote
-    6:
       InfoResponse:
         NEWTYPE:
           TYPENAME: AccountInfoResponse
+    6:
+      CoinCreationResponse:
+        NEWTYPE:
+          TYPENAME: CoinCreationResponse
     7:
       Error:
         NEWTYPE:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -417,7 +417,7 @@ OpaqueCoin:
         TYPENAME: AccountId
     - public_seed: U128
     - private_seed: U128
-    - value:
+    - amount:
         TYPENAME: Amount
 Operation:
   ENUM:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -56,13 +56,6 @@ Certificate:
           TUPLE:
             - TYPENAME: PublicKeyBytes
             - TYPENAME: Signature
-Coin:
-  STRUCT:
-    - account_id:
-        TYPENAME: AccountId
-    - amount:
-        TYPENAME: Amount
-    - seed: U128
 CoinCreationDescription:
   STRUCT:
     - sources:
@@ -70,7 +63,7 @@ CoinCreationDescription:
           TYPENAME: CoinCreationSource
     - targets:
         SEQ:
-          TYPENAME: Coin
+          TYPENAME: TransparentCoin
 CoinCreationOrder:
   STRUCT:
     - description:
@@ -312,6 +305,13 @@ Signature:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 64
+TransparentCoin:
+  STRUCT:
+    - account_id:
+        TYPENAME: AccountId
+    - amount:
+        TYPENAME: Amount
+    - seed: U128
 UserData:
   NEWTYPESTRUCT:
     OPTION:
@@ -331,7 +331,7 @@ Value:
     2:
       Coin:
         NEWTYPE:
-          TYPENAME: Coin
+          TYPENAME: TransparentCoin
 Vote:
   STRUCT:
     - value:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -45,6 +45,16 @@ Address:
           TYPENAME: AccountId
 Amount:
   NEWTYPESTRUCT: U64
+Asset:
+  ENUM:
+    0:
+      TransparentCoin:
+        NEWTYPE:
+          TYPENAME: Certificate
+    1:
+      OpaqueCoin:
+        NEWTYPE:
+          TYPENAME: OpaqueCoin
 Balance:
   NEWTYPESTRUCT: I128
 Certificate:
@@ -56,6 +66,10 @@ Certificate:
           TUPLE:
             - TYPENAME: PublicKeyBytes
             - TYPENAME: Signature
+Coin:
+  TUPLESTRUCT:
+    - TYPENAME: G1
+    - TYPENAME: G1
 CoinCreationDescription:
   STRUCT:
     - sources:
@@ -64,6 +78,9 @@ CoinCreationDescription:
     - targets:
         SEQ:
           TYPENAME: TransparentCoin
+    - coconut_request:
+        OPTION:
+          TYPENAME: CoinsRequest
 CoinCreationOrder:
   STRUCT:
     - description:
@@ -77,9 +94,38 @@ CoinCreationSource:
         TYPENAME: AccountId
     - account_balance:
         TYPENAME: Amount
-    - coins:
+    - transparent_coins:
         SEQ:
           TYPENAME: Certificate
+    - opaque_coin_public_seeds:
+        SEQ: U128
+CoinsRequest:
+  STRUCT:
+    - sigmas:
+        SEQ:
+          TYPENAME: Coin
+    - kappas:
+        SEQ:
+          TYPENAME: G2
+    - cms:
+        SEQ:
+          TYPENAME: G1
+    - cs:
+        SEQ:
+          TUPLEARRAY:
+            CONTENT:
+              TYPENAME: G1
+            SIZE: 3
+    - input_commitments:
+        SEQ:
+          TYPENAME: G1
+    - output_commitments:
+        SEQ:
+          TYPENAME: G1
+    - proof:
+        TYPENAME: RequestCoinsProof
+    - range_proof:
+        TYPENAME: RangeProof
 ConfirmationOrder:
   STRUCT:
     - certificate:
@@ -157,36 +203,204 @@ FastPayError:
     20:
       InvalidCoin: UNIT
     21:
-      CertificateNotFound: UNIT
+      InvalidAsset: UNIT
     22:
-      InvalidCrossShardRequest: UNIT
+      CertificateNotFound: UNIT
     23:
-      InvalidRequestOrder: UNIT
+      InvalidCrossShardRequest: UNIT
     24:
-      InvalidConfirmationOrder: UNIT
+      InvalidRequestOrder: UNIT
     25:
-      InvalidCoinCreationOrder: UNIT
+      InvalidConfirmationOrder: UNIT
     26:
-      ClientErrorWhileProcessingRequestOrder: UNIT
+      InvalidCoinCreationOrder: UNIT
     27:
-      ClientErrorWhileProcessingCoinCreationOrder: UNIT
+      ClientErrorWhileProcessingRequestOrder: UNIT
     28:
-      ClientErrorWhileRequestingCertificate: UNIT
+      ClientErrorWhileProcessingCoinCreationOrder: UNIT
     29:
-      WrongShard: UNIT
+      ClientErrorWhileRequestingCertificate: UNIT
     30:
-      InvalidDecoding: UNIT
+      WrongShard: UNIT
     31:
-      UnexpectedMessage: UNIT
+      InvalidDecoding: UNIT
     32:
+      UnexpectedMessage: UNIT
+    33:
       ClientIoError:
         STRUCT:
           - error: STR
+G1:
+  TUPLESTRUCT:
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+G2:
+  TUPLESTRUCT:
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
 HashValue:
   NEWTYPESTRUCT:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 64
+InputAttribute:
+  STRUCT:
+    - seed:
+        TYPENAME: Scalar
+    - value:
+        TYPENAME: Scalar
+    - id:
+        TYPENAME: Scalar
+OpaqueCoin:
+  STRUCT:
+    - id:
+        TYPENAME: AccountId
+    - public_seed: U128
+    - private_seed: U128
+    - value:
+        TYPENAME: Amount
+    - coin:
+        TYPENAME: Coin
 Operation:
   ENUM:
     0:
@@ -228,11 +442,42 @@ Operation:
               TYPENAME: Amount
           - user_data:
               TYPENAME: UserData
+OutputAttribute:
+  STRUCT:
+    - seed:
+        TYPENAME: Scalar
+    - seed_blinding_factor:
+        TYPENAME: Scalar
+    - value:
+        TYPENAME: Scalar
+    - value_blinding_factor:
+        TYPENAME: Scalar
+    - id:
+        TYPENAME: Scalar
+    - id_blinding_factor:
+        TYPENAME: Scalar
 PublicKeyBytes:
   NEWTYPESTRUCT:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 32
+Randomness:
+  STRUCT:
+    - rs:
+        SEQ:
+          TYPENAME: Scalar
+    - os:
+        SEQ:
+          TYPENAME: Scalar
+    - input_rs:
+        SEQ:
+          TYPENAME: Scalar
+    - output_rs:
+        SEQ:
+          TYPENAME: Scalar
+RangeProof:
+  NEWTYPESTRUCT:
+    SEQ: U8
 Request:
   STRUCT:
     - account_id:
@@ -241,6 +486,20 @@ Request:
         TYPENAME: Operation
     - sequence_number:
         TYPENAME: SequenceNumber
+RequestCoinsProof:
+  STRUCT:
+    - challenge:
+        TYPENAME: Scalar
+    - input_attributes_responses:
+        SEQ:
+          TYPENAME: InputAttribute
+    - output_attributes_responses:
+        SEQ:
+          TYPENAME: OutputAttribute
+    - randomness_responses:
+        TYPENAME: Randomness
+    - zero_sum_response:
+        TYPENAME: Scalar
 RequestOrder:
   STRUCT:
     - value:
@@ -251,7 +510,7 @@ RequestOrder:
         TYPENAME: Signature
     - assets:
         SEQ:
-          TYPENAME: Certificate
+          TYPENAME: Asset
 RequestValue:
   STRUCT:
     - request:
@@ -259,6 +518,40 @@ RequestValue:
     - limited_to:
         OPTION:
           TYPENAME: PublicKeyBytes
+Scalar:
+  TUPLESTRUCT:
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
+    - U8
 SequenceNumber:
   NEWTYPESTRUCT: U64
 SerializedMessage:

--- a/fastpay_core/tests/staged/fastpay.yaml
+++ b/fastpay_core/tests/staged/fastpay.yaml
@@ -389,7 +389,7 @@ InputAttribute:
         TYPENAME: Scalar
     - value:
         TYPENAME: Scalar
-    - id:
+    - key:
         TYPENAME: Scalar
 OpaqueCoin:
   STRUCT:
@@ -452,9 +452,9 @@ OutputAttribute:
         TYPENAME: Scalar
     - value_blinding_factor:
         TYPENAME: Scalar
-    - id:
+    - key:
         TYPENAME: Scalar
-    - id_blinding_factor:
+    - key_blinding_factor:
         TYPENAME: Scalar
 PublicKeyBytes:
   NEWTYPESTRUCT:


### PR DESCRIPTION
Use the coconut library (including bulletproofs) to implement fully "anonymous coins" (next to "transparent coins") in FastPay.

* Both coins are stored by their owner as a new data structure called `Asset`
* Includes two changes in Coconut: minor renaming + remove incorrect verification check in proofs
* Still lacking unit tests (in particular poking around all the security invariants)